### PR TITLE
Fix disappearing Active Filter Datasets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 * Changed constructor of `FilteredData` to not require `TealData` object. See `help(init_filtered_data)` for more details.
 * The filtered data is now stored in `FilteredData` not `FilteredDataset`. 
 
+# Bug fixes
+
+* Fixed a bug when the filter panel overview would not refresh if the panel was hidden during a transition between active modules.
+
 # teal.slice 0.1.1
 
 ### New features

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -898,7 +898,9 @@ FilteredData <- R6::R6Class( # nolint
             logger::log_trace("FilteredData$srv_filter_overview@1 updated counts")
             table_html
           })
-
+          
+          shiny::outputOptions(output, "table", suspendWhenHidden = FALSE)
+          
           logger::log_trace("FilteredData$srv_filter_overview initialized")
           NULL
         }

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -898,9 +898,7 @@ FilteredData <- R6::R6Class( # nolint
             logger::log_trace("FilteredData$srv_filter_overview@1 updated counts")
             table_html
           })
-          
           shiny::outputOptions(output, "table", suspendWhenHidden = FALSE)
-          
           logger::log_trace("FilteredData$srv_filter_overview initialized")
           NULL
         }


### PR DESCRIPTION
closes #59 

We want to sustain the process even when the part of UI is temporarily hidden.