### PR TITLE
stay with the current view

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -883,7 +883,6 @@ FilteredData <- R6::R6Class( # nolint
             "FilteredData$srv_filter_panel@1 active datanames: { paste(active_datanames(), collapse = \" \") }"
           )
 
-          private$hide_inactive_datasets(active_datanames)
           if (length(active_datanames()) == 0 || is.null(active_datanames())) {
             # The filter panel emits an event when there are no active datasets
             # so the parent modules can hide the filter panel if needed.
@@ -902,26 +901,6 @@ FilteredData <- R6::R6Class( # nolint
           shinyjs::runjs(script)
         },
         ignoreNULL = FALSE
-      )
-    },
-
-    # selectively hide / show to only show `active_datanames` out of all datanames
-    hide_inactive_datasets = function(active_datanames) {
-      lapply(
-        self$datanames(),
-        function(dataname) {
-          id_add_filter <- private$get_ui_add_filter_id(dataname)
-          id_filter_dataname <- private$get_ui_id(dataname)
-
-          if (dataname %in% active_datanames()) {
-            # shinyjs takes care of the namespace around the id
-            shinyjs::show(id_add_filter)
-            shinyjs::show(id_filter_dataname)
-          } else {
-            shinyjs::hide(id_add_filter)
-            shinyjs::hide(id_filter_dataname)
-          }
-        }
       )
     },
 


### PR DESCRIPTION
remove additional functionality if we want to persist the functionality. We have all filters available no matter of the active datanames of a certain module.

With the new PR we limit Active Filter Variables and Add Filter Variables to have only values from datasets in Active Filter Summary 

<img src="https://user-images.githubusercontent.com/10676545/178579740-9ead4d7d-5c44-41e7-b9d1-a2562efae19b.png" height="450px" width="250px"> 

Where as now we always adding all of them

<img src="https://user-images.githubusercontent.com/10676545/178580169-3ceb0ad4-009f-4ec9-acc1-77d66ba5863f.png" height="450px" width="250px"> 


