### PR TITLE
add joinkeys into filtered data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Removed `CDISCFilteredDataset` class and functionality moved to `CDISCFilteredData`.
 * Changed constructor of `FilteredData` to not require `TealData` object. See `help(init_filtered_data)` for more details.
 * The filtered data is now stored in `FilteredData` not `FilteredDataset`.
+* The join keys stored inside `FilteredData` are now `JoinKeys` objects.
 
 # Bug fixes
 

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -250,7 +250,11 @@ FilteredData <- R6::R6Class( # nolint
       if (is.null(private$keys)) {
         return(character(0))
       }
-      private$keys$get(dataset_1, dataset_2)
+      keys <- private$keys$get(dataset_1, dataset_2)
+      if (length(keys) == 0) {
+        return(character(0))
+      }
+      return(keys)
     },
 
     #' @description

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -247,19 +247,7 @@ FilteredData <- R6::R6Class( # nolint
     #' @param dataset_2 (`character(1)`) other dataset name
     #' @return (`named character`) vector with column names
     get_join_keys = function(dataset_1, dataset_2) {
-      res <- if (!missing(dataset_1) && !missing(dataset_2)) {
-        private$keys[[dataset_1]][[dataset_2]]
-      } else if (!missing(dataset_1)) {
-        private$keys[[dataset_2]]
-      } else if (!missing(dataset_2)) {
-        private$keys[[dataset_1]]
-      } else {
-        private$keys
-      }
-      if (length(res) == 0) {
-        return(character(0))
-      }
-      return(res)
+      private$keys$get(dataset_1, dataset_2)
     },
 
     #' @description
@@ -388,7 +376,7 @@ FilteredData <- R6::R6Class( # nolint
     #' @return (`self`) invisibly this `FilteredData`
     set_join_keys = function(join_keys) {
       checkmate::assert_class(join_keys, "JoinKeys")
-      private$keys <- join_keys$get()
+      private$keys <- join_keys
       invisible(self)
     },
 
@@ -902,7 +890,7 @@ FilteredData <- R6::R6Class( # nolint
     # preprocessing code used to generate the unfiltered datasets as a string
     code = NULL,
 
-    # keys used for joining/filtering data named nested lists
+    # keys used for joining/filtering data a JoinKeys object (see teal.data)
     keys = NULL,
 
     # reactive i.e. filtered data

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -247,6 +247,9 @@ FilteredData <- R6::R6Class( # nolint
     #' @param dataset_2 (`character(1)`) other dataset name
     #' @return (`named character`) vector with column names
     get_join_keys = function(dataset_1, dataset_2) {
+      if (is.null(private$keys)) {
+        return(character(0))
+      }
       private$keys$get(dataset_1, dataset_2)
     },
 

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -14,15 +14,53 @@ testthat::test_that("set_dataset returns self", {
   testthat::expect_identical(filtered_data$set_dataset(dataset_args = dataset_args, dataname = "iris"), filtered_data)
 })
 
-testthat::test_that("get_keys returns an empty character when data has no keys", {
+testthat::test_that("get_keys returns an empty character when dataset has no keys", {
   filtered_data <- FilteredData$new(list(iris = list(dataset = head(iris), keys = character(0))), join_keys = NULL)
   testthat::expect_equal(filtered_data$get_keys("iris"), character(0))
 })
 
-test_that("get_keys returns the same character array if a TealDataset has keys", {
+testthat::test_that("get_keys returns the same character array if a dataset has keys", {
   filtered_data <- FilteredData$new(list(iris = list(dataset = head(iris), keys = "test")), join_keys = NULL)
   testthat::expect_equal(filtered_data$get_keys("iris"), "test")
 })
+
+testthat::test_that("get_join_keys returns empty character if no join_keys", {
+  filtered_data <- FilteredData$new(list(iris = list(dataset = head(iris), keys = "test")), join_keys = NULL)
+  testthat::expect_equal(filtered_data$get_join_keys(), character(0))
+})
+
+testthat::test_that("get_join_keys returns empty character if no join_keys for specific datasets", {
+  filtered_data <- FilteredData$new(
+    list(
+      iris = list(dataset = head(iris)),
+      iris2 = list(dataset = head(iris)),
+      iris3 = list(dataset = head(iris))
+    ),
+    join_keys = teal.data::join_keys(
+      teal.data::join_key("iris2", "iris3", c("Species" = "Species"))
+    )
+  )
+  testthat::expect_equal(filtered_data$get_join_keys("iris"), character(0))
+  testthat::expect_equal(filtered_data$get_join_keys("iris", "iris2"), character(0))
+  testthat::expect_equal(filtered_data$get_join_keys("iris2", "iris"), character(0))
+})
+
+testthat::test_that("get_join_keys returns join_keys for specific datasets if they exist", {
+  filtered_data <- FilteredData$new(
+    list(
+      iris = list(dataset = head(iris)),
+      iris2 = list(dataset = head(iris)),
+      iris3 = list(dataset = head(iris))
+    ),
+    join_keys = teal.data::join_keys(
+      teal.data::join_key("iris2", "iris3", c("Species" = "Sepal.Length"))
+    )
+  )
+  testthat::expect_equal(filtered_data$get_join_keys("iris2"), list("iris3" = c("Species" = "Sepal.Length")))
+  testthat::expect_equal(filtered_data$get_join_keys("iris2", "iris3"), c("Species" = "Sepal.Length"))
+  testthat::expect_equal(filtered_data$get_join_keys("iris3", "iris2"), c("Sepal.Length" = "Species"))
+})
+
 
 testthat::test_that("get_varnames returns dataname's column names", {
   filtered_data <- FilteredData$new(list(iris = list(dataset = head(iris))), join_keys = NULL)

--- a/vignettes/filter-panel.Rmd
+++ b/vignettes/filter-panel.Rmd
@@ -16,6 +16,7 @@ The key changes not yet incorporated:
 2) `FilteredDataset` no longer contains reactive data this is stored inside `FilteredData` instead.
 3) It is also possible to create a `FilteredData` object directly from a list of data.frames without
 create a `TealData` object see `help(init_filtered_data)` for more details.
+4) `FilteredData$private$keys` is now a `JoinKeys` object instead of a nested list.  
 
 ## Overview
 


### PR DESCRIPTION
Closes #63 but note this is not fixing https://github.com/insightsengineering/teal/issues/683 note I've checked teal.transform and all the tests pass there and the vignette behaviour is the same as on main.

Please also tests a few tmg or tmc modules

