### PR TITLE
Update get_filter_state

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -417,11 +417,15 @@ FilteredData <- R6::R6Class( # nolint
     #'
     #' Gets all active filters in the form of a nested list.
     #' The output list is a compatible input to `self$set_filter_state`.
+    #' The attribute `formatted` renders the output of `self$get_formatted_filter_state` which
+    #' is a character formatting of the filter state.
     #' @return `list` with named elements corresponding to `FilteredDataset` objects
-    #' with active filters.
+    #' with active filters. Additionally, an attribute `formatted` holds the character format of
+    #' the active filter states.
     get_filter_state = function() {
       states <- lapply(self$get_filtered_dataset(), function(x) x$get_filter_state())
-      Filter(function(x) length(x) > 0, states)
+      filtered_states <- Filter(function(x) length(x) > 0, states)
+      structure(filtered_states, formatted = self$get_formatted_filter_state())
     },
 
     #' @description

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -649,13 +649,16 @@ Gets the reactive values from the active \code{FilterState} objects.
 
 Gets all active filters in the form of a nested list.
 The output list is a compatible input to \code{self$set_filter_state}.
+The attribute \code{formatted} renders the output of \code{self$get_formatted_filter_state} which
+is a character formatting of the filter state.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilteredData$get_filter_state()}\if{html}{\out{</div>}}
 }
 
 \subsection{Returns}{
 \code{list} with named elements corresponding to \code{FilteredDataset} objects
-with active filters.
+with active filters. Additionally, an attribute \code{formatted} holds the character format of
+the active filter states.
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -258,7 +258,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("FilteredData$get_filter_state returns list identical to input",
+testthat::test_that("FilteredData$get_filter_state returns list identical to input with attributes",
   code = {
     utils::data(miniACC, package = "MultiAssayExperiment")
     datasets <- FilteredData$new(
@@ -287,7 +287,47 @@ testthat::test_that("FilteredData$get_filter_state returns list identical to inp
       )
     )
     datasets$set_filter_state(state = fs)
+    attr(fs, "formatted") <- isolate(datasets$get_formatted_filter_state())
     testthat::expect_identical(isolate(datasets$get_filter_state()), fs)
+  }
+)
+
+testthat::test_that("FilteredData$get_filter_state returns list whose attribute is a character form of the list",
+  code = {
+    utils::data(miniACC, package = "MultiAssayExperiment")
+    datasets <- FilteredData$new(
+      list(
+        iris = list(dataset = iris),
+        mtcars = list(dataset = mtcars),
+        mae = list(dataset = miniACC)
+      ),
+      join_keys = NULL
+    )
+
+    fs <- list(
+      iris = list(
+        Sepal.Length = list(selected = c(5.1, 6.4), keep_na = TRUE, keep_inf = FALSE),
+        Species = list(selected = c("setosa", "versicolor"), keep_na = FALSE)
+      ),
+      mae = list(
+        subjects = list(
+          years_to_birth = list(selected = c(30, 50), keep_na = TRUE, keep_inf = FALSE),
+          vital_status = list(selected = "1", keep_na = FALSE),
+          gender = list(selected = "female", keep_na = TRUE)
+        ),
+        RPPAArray = list(
+          subset = list(ARRAY_TYPE = list(selected = "", keep_na = TRUE))
+        )
+      )
+    )
+    datasets$set_filter_state(state = fs)
+    formatted_attr <- isolate(datasets$get_formatted_filter_state())
+
+    testthat::expect_type(formatted_attr, "character")
+    testthat::expect_identical(
+      attr(isolate(datasets$get_filter_state()), "formatted"),
+      formatted_attr
+    )
   }
 )
 
@@ -311,14 +351,16 @@ testthat::test_that("FilteredData$remove_filter_state removes states defined in 
   )
   datasets$set_filter_state(state = fs)
   datasets$remove_filter_state(state = list(iris = "Sepal.Length", mtcars = c("cyl", "disp")))
+  fs_after_remove <- list(
+    iris = list(
+      Species = list(selected = c("setosa", "versicolor"), keep_na = FALSE)
+    )
+  )
+  attr(fs_after_remove, "formatted") <- isolate(datasets$get_formatted_filter_state())
 
   testthat::expect_identical(
     isolate(datasets$get_filter_state()),
-    list(
-      iris = list(
-        Species = list(selected = c("setosa", "versicolor"), keep_na = FALSE)
-      )
-    )
+    fs_after_remove
   )
 })
 

--- a/tests/testthat/test-filter_panel_api.R
+++ b/tests/testthat/test-filter_panel_api.R
@@ -34,7 +34,7 @@ testthat::test_that("FilterPanelAPI$set_filter_state sets filters specified by t
   }
 )
 
-testthat::test_that("FilterPanelAPI$get_filter_state returns list identical to input",
+testthat::test_that("FilterPanelAPI$get_filter_state returns list identical to input without attribute",
   code = {
     datasets <- FilterPanelAPI$new(filtered_data)
 
@@ -48,8 +48,11 @@ testthat::test_that("FilterPanelAPI$get_filter_state returns list identical to i
       )
     )
     datasets$set_filter_state(filter_list)
+    fs_wo_attr <- isolate(datasets$get_filter_state())
+    attr(fs_wo_attr, "formatted") <- NULL
+
     testthat::expect_equal(
-      isolate(datasets$get_filter_state()),
+      fs_wo_attr,
       filter_list
     )
   }
@@ -68,9 +71,11 @@ testthat::test_that("FilterPanelAPI$remove_filter_state removes filter states de
   )
   datasets$set_filter_state(filter_list)
   datasets$remove_filter_state(filter = list(iris = "Sepal.Length"))
+  fs_wo_attr <- isolate(datasets$get_filter_state())
+  attr(fs_wo_attr, "formatted") <- NULL
 
   testthat::expect_identical(
-    isolate(datasets$get_filter_state()),
+    fs_wo_attr,
     list(
       iris = list(Species = list(selected = c("setosa", "versicolor"), keep_na = FALSE)),
       mtcars = list(hp = list(selected = c(52, 65), keep_na = FALSE, keep_inf = FALSE))
@@ -116,9 +121,11 @@ testthat::test_that(
     )
     datasets$set_filter_state(filter_list)
     datasets$remove_all_filter_states(datanames = "iris")
+    fs_wo_attr <- isolate(datasets$get_filter_state())
+    attr(fs_wo_attr, "formatted") <- NULL
 
     testthat::expect_equal(
-      isolate(datasets$get_filter_state()),
+      fs_wo_attr,
       list(mtcars = list(
         hp = list(selected = c(52, 65), keep_na = FALSE, keep_inf = FALSE)
       ))


### PR DESCRIPTION
closes #61 
related PR: 

After a discussion with @nikolas-burkoff and @Polkas , we decided to update `FilteredData::get_filter_state` by adding an attribute to the returned list which is the output of `get_formatted_filter_state`.
The list is used to append meta data and the character output of `get_formatted_filter_state` is used to append text to the reporter.

Please test with anu tmg, tmc, tmg ... module.