### PR TITLE
Update font awesome icon labels for FA 6

### DIFF
--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -36,7 +36,7 @@
 #' \dontrun{
 #' shinyApp(
 #'   ui = fluidPage(
-#'     actionButton("clear", span(icon("times"), "Remove all filters")),
+#'     actionButton("clear", span(icon("xmark"), "Remove all filters")),
 #'     rf$ui_add_filter_state(id = "add", data = df),
 #'     rf$ui("states"),
 #'     verbatimTextOutput("expr"),
@@ -577,7 +577,7 @@ FilterStates <- R6::R6Class( # nolint
                       actionLink(
                         session$ns("remove"),
                         label = "",
-                        icon = icon("times-circle", lib = "font-awesome"),
+                        icon = icon("circle-xmark", lib = "font-awesome"),
                         class = "remove pull-right"
                       )
                     )

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -603,7 +603,7 @@ FilteredData <- R6::R6Class( # nolint
                   ns("filters_overview_contents")
                 ),
                 title = "Minimise panel",
-                tags$span(icon("minus-circle", lib = "font-awesome"))
+                tags$span(icon("circle-minus", lib = "font-awesome"))
               )
             )
           ),
@@ -639,7 +639,7 @@ FilteredData <- R6::R6Class( # nolint
                   ns("filter_active_vars_contents")
                 ),
                 title = "Minimise panel",
-                tags$span(icon("minus-circle", lib = "font-awesome"))
+                tags$span(icon("circle-minus", lib = "font-awesome"))
               )
             )
           ),
@@ -672,7 +672,7 @@ FilteredData <- R6::R6Class( # nolint
                 class = "remove pull-right",
                 onclick = sprintf("$('#%s').toggle();", ns("filter_add_vars_contents")),
                 title = "Minimise panel",
-                tags$span(icon("minus-circle", lib = "font-awesome"))
+                tags$span(icon("circle-minus", lib = "font-awesome"))
               )
             )
           ),

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -350,7 +350,7 @@ FilteredDataset <- R6::R6Class( # nolint
               actionLink(
                 ns("remove_filters"),
                 label = "",
-                icon = icon("times-circle", lib = "font-awesome"),
+                icon = icon("circle-xmark", lib = "font-awesome"),
                 class = "remove pull-right"
               )
             )

--- a/man/init_filter_states.Rd
+++ b/man/init_filter_states.Rd
@@ -50,7 +50,7 @@ rf <- teal.slice:::init_filter_states(
 \dontrun{
 shinyApp(
   ui = fluidPage(
-    actionButton("clear", span(icon("times"), "Remove all filters")),
+    actionButton("clear", span(icon("xmark"), "Remove all filters")),
     rf$ui_add_filter_state(id = "add", data = df),
     rf$ui("states"),
     verbatimTextOutput("expr"),


### PR DESCRIPTION
Update font awesome icon labels for FA 6, to avoid warnings like:

```
This Font Awesome icon ('some icon') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
```