### PR TITLE
double operator changed to single for MAEFilterStates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,11 +5,11 @@
 * The filtered data is now stored in `FilteredData` not `FilteredDataset`.
 * The join keys stored inside `FilteredData` are now `JoinKeys` objects.
 * Updated `get_filter_state` to return a list of active filter states and an attribute with the character form of the filter states.
+* In `FilterStates`, `varlabels` are now described as character vector, also removed usage of `||` to acomodate for vector input.
 
 # Bug fixes
 
 * Fixed a bug when the filter panel overview would not refresh if the panel was hidden during a transition between active modules.
-* Fixed a bug where `varlabels` were assumed to be a character in `FilterStates` (now it is a character vector) and a `||` was used.
 
 # teal.slice 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * The filtered data is now stored in `FilteredData` not `FilteredDataset`.
 * The join keys stored inside `FilteredData` are now `JoinKeys` objects.
 * Updated `get_filter_state` to return a list of active filter states and an attribute with the character form of the filter states.
-* In `FilterStates`, `varlabels` are now described as character vector, also removed usage of `||` to accommodate for vector input.
+* Updated `get_varlabels` method in the `FilterStates` classes, accepts a vector input.
 
 # Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * The filtered data is now stored in `FilteredData` not `FilteredDataset`.
 * The join keys stored inside `FilteredData` are now `JoinKeys` objects.
 * Updated `get_filter_state` to return a list of active filter states and an attribute with the character form of the filter states.
-* In `FilterStates`, `varlabels` are now described as character vector, also removed usage of `||` to acomodate for vector input.
+* In `FilterStates`, `varlabels` are now described as character vector, also removed usage of `||` to accomodate for vector input.
 
 # Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,7 @@
 # Bug fixes
 
 * Fixed a bug when the filter panel overview would not refresh if the panel was hidden during a transition between active modules.
-
-* Fixed a bug where varlabels were assumed to be a character (now it is a character vector) and a || was used.
+* Fixed a bug where `varlabels` were assumed to be a character in `FilterStates` (now it is a character vector) and a || was used.
 
 # teal.slice 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Fixed a bug when the filter panel overview would not refresh if the panel was hidden during a transition between active modules.
 
+* Fixed a bug where varlabels were assumed to be a character (now it is a character vector) and a || was used.
+
 # teal.slice 0.1.1
 
 ### New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 # Bug fixes
 
 * Fixed a bug when the filter panel overview would not refresh if the panel was hidden during a transition between active modules.
-* Fixed a bug where `varlabels` were assumed to be a character in `FilterStates` (now it is a character vector) and a || was used.
+* Fixed a bug where `varlabels` were assumed to be a character in `FilterStates` (now it is a character vector) and a `||` was used.
 
 # teal.slice 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * The filtered data is now stored in `FilteredData` not `FilteredDataset`.
 * The join keys stored inside `FilteredData` are now `JoinKeys` objects.
 * Updated `get_filter_state` to return a list of active filter states and an attribute with the character form of the filter states.
-* In `FilterStates`, `varlabels` are now described as character vector, also removed usage of `||` to accomodate for vector input.
+* In `FilterStates`, `varlabels` are now described as character vector, also removed usage of `||` to accommodate for vector input.
 
 # Bug fixes
 

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -1072,7 +1072,7 @@ DFFilterStates <- R6::R6Class( # nolint
     #'  name of the variable for which label should be returned
     #' return `character`
     get_varlabels = function(variables = character(0)) {
-      stopifnot(is.character(variables))
+      checkmate::assert_character(variables)
       if (identical(variables, character(0))) {
         private$varlabels
       } else {
@@ -1449,7 +1449,7 @@ MAEFilterStates <- R6::R6Class( # nolint
     #'  name of the variable for which label should be returned
     #' return `character`
     get_varlabels = function(variables = character(0)) {
-      stopifnot(is.character(variables))
+      checkmate::assert_character(variables)
       if (identical(variables, character(0))) {
         private$varlabels
       } else {

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -1068,18 +1068,17 @@ DFFilterStates <- R6::R6Class( # nolint
     #' description
     #' Get label of specific variable. In case when variable label is missing
     #' name of the variable is returned.
-    #' parameter variable (`character(1)`)\cr
+    #' parameter variable (`character`)\cr
     #'  name of the variable for which label should be returned
-    #' return `character(1)`
+    #' return `character`
     get_varlabels = function(variables = character(0)) {
       stopifnot(is.character(variables))
       if (identical(variables, character(0))) {
         private$varlabels
       } else {
         varlabels <- private$varlabels[variables]
-        varlabels[is.na(varlabels) | varlabels == ""] <- variables[
-          is.na(varlabels) | varlabels == ""
-        ]
+        missing_labels <- is.na(varlabels) | varlabels == ""
+        varlabels[missing_labels] <- variables[missing_labels]
         varlabels
       }
     }
@@ -1446,18 +1445,17 @@ MAEFilterStates <- R6::R6Class( # nolint
     #' description
     #' Get label of specific variable. In case when variable label is missing
     #' name of the variable is returned.
-    #' parameter variable (`character(1)`)\cr
+    #' parameter variable (`character`)\cr
     #'  name of the variable for which label should be returned
-    #' return `character(1)`
+    #' return `character`
     get_varlabels = function(variables = character(0)) {
       stopifnot(is.character(variables))
       if (identical(variables, character(0))) {
         private$varlabels
       } else {
         varlabels <- private$varlabels[variables]
-        varlabels[is.na(varlabels) | varlabels == ""] <- variables[
-          is.na(varlabels) | varlabels == ""
-        ]
+        missing_labels <- is.na(varlabels) | varlabels == ""
+        varlabels[missing_labels] <- variables[missing_labels]
         varlabels
       }
     }

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -1455,8 +1455,8 @@ MAEFilterStates <- R6::R6Class( # nolint
         private$varlabels
       } else {
         varlabels <- private$varlabels[variables]
-        varlabels[is.na(varlabels) || varlabels == ""] <- variables[
-          is.na(varlabels) || varlabels == ""
+        varlabels[is.na(varlabels) | varlabels == ""] <- variables[
+          is.na(varlabels) | varlabels == ""
         ]
         varlabels
       }

--- a/man/DFFilterStates.Rd
+++ b/man/DFFilterStates.Rd
@@ -311,9 +311,9 @@ optional, vector of column names to be included.}
 description
 Get label of specific variable. In case when variable label is missing
 name of the variable is returned.
-parameter variable (\code{character(1)})\cr
+parameter variable (\code{character})\cr
 name of the variable for which label should be returned
-return \code{character(1)}
+return \code{character}
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/MAEFilterStates.Rd
+++ b/man/MAEFilterStates.Rd
@@ -255,9 +255,9 @@ object containing \code{colData} which columns are used to choose filter variabl
 description
 Get label of specific variable. In case when variable label is missing
 name of the variable is returned.
-parameter variable (\code{character(1)})\cr
+parameter variable (\code{character})\cr
 name of the variable for which label should be returned
-return \code{character(1)}
+return \code{character}
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-MAEFilterStates.R
+++ b/tests/testthat/test-MAEFilterStates.R
@@ -3,7 +3,7 @@ testthat::test_that("The constructor does not throw", {
     input_dataname = "test",
     output_dataname = "test",
     datalabel = character(0),
-    varlabels = character(0),
+    varlabels = "varblabel1",
     keys = character(0)
   ), NA)
 })
@@ -36,7 +36,7 @@ testthat::test_that("get_call returns a call filtering an MAE object using Choic
     input_dataname = "test",
     output_dataname = "output",
     datalabel = character(0),
-    varlabels = character(0),
+    varlabels = paste0("varlabel", 1:100),
     keys = character(0)
   )
   filter_state <- ChoicesFilterState$new(
@@ -62,7 +62,7 @@ testthat::test_that("get_call returns a call filtering an MAE object using Range
     input_dataname = "test",
     output_dataname = "output",
     datalabel = character(0),
-    varlabels = character(0),
+    varlabels = c(NA, "", "label1"),
     keys = character(0)
   )
   filter_state <- RangeFilterState$new(
@@ -97,7 +97,7 @@ testthat::test_that(
       input_dataname = "test",
       output_dataname = "test_filtered",
       datalabel = character(0),
-      varlabels = character(0),
+      varlabels = NA,
       keys = character(0)
     )
     fs <- list(
@@ -185,7 +185,7 @@ testthat::test_that(
       input_dataname = "test",
       output_dataname = "test_filtered",
       datalabel = character(0),
-      varlabels = character(0),
+      varlabels = c(NA, "", paste0("label", 1:10)),
       keys = character(0)
     )
     fs <- list(
@@ -301,7 +301,7 @@ testthat::test_that("$format() asserts the indent argument is a number", {
       input_dataname = "iris",
       output_dataname = "iris_filtered",
       datalabel = character(0),
-      varlabels = character(0),
+      varlabels = paste0("varlabel", 1:100),
       keys = character(0)
     )$format(indent = "wrong type"),
     regexp = "Assertion on 'indent' failed: Must be of type 'number'"
@@ -314,7 +314,7 @@ testthat::test_that("$format() concatenates its FilterState elements using \\n a
     input_dataname = "test",
     output_dataname = "test_filtered",
     datalabel = character(0),
-    varlabels = character(0),
+    varlabels = paste0("varlabel", 1:100),
     keys = character(0)
   )
 

--- a/tests/testthat/test-MAEFilterStates.R
+++ b/tests/testthat/test-MAEFilterStates.R
@@ -3,9 +3,20 @@ testthat::test_that("The constructor does not throw", {
     input_dataname = "test",
     output_dataname = "test",
     datalabel = character(0),
-    varlabels = "varlabel1",
+    varlabels = character(0),
     keys = character(0)
   ), NA)
+})
+
+testthat::test_that("MAEFilterStates accept vector as an input for varlabels", {
+  filter_states <- MAEFilterStates$new(
+    input_dataname = "iris",
+    output_dataname = "iris",
+    datalabel = character(0),
+    varlabels = c("", NA, paste0("varlabel", 1:100)),
+    keys = character(0)
+  )
+  testthat::expect_equal(filter_states$get_fun(), "MultiAssayExperiment::subsetByColData")
 })
 
 testthat::test_that("get_fun returns the MAE specific subset function", {
@@ -36,7 +47,7 @@ testthat::test_that("get_call returns a call filtering an MAE object using Choic
     input_dataname = "test",
     output_dataname = "output",
     datalabel = character(0),
-    varlabels = paste0("varlabel", 1:100),
+    varlabels = character(0),
     keys = character(0)
   )
   filter_state <- ChoicesFilterState$new(
@@ -62,7 +73,7 @@ testthat::test_that("get_call returns a call filtering an MAE object using Range
     input_dataname = "test",
     output_dataname = "output",
     datalabel = character(0),
-    varlabels = c(NA, "", "label1"),
+    varlabels = character(0),
     keys = character(0)
   )
   filter_state <- RangeFilterState$new(
@@ -97,7 +108,7 @@ testthat::test_that(
       input_dataname = "test",
       output_dataname = "test_filtered",
       datalabel = character(0),
-      varlabels = NA,
+      varlabels = character(0),
       keys = character(0)
     )
     fs <- list(
@@ -185,7 +196,7 @@ testthat::test_that(
       input_dataname = "test",
       output_dataname = "test_filtered",
       datalabel = character(0),
-      varlabels = c(NA, "", paste0("label", 1:10)),
+      varlabels = character(0),
       keys = character(0)
     )
     fs <- list(
@@ -301,7 +312,7 @@ testthat::test_that("$format() asserts the indent argument is a number", {
       input_dataname = "iris",
       output_dataname = "iris_filtered",
       datalabel = character(0),
-      varlabels = paste0("varlabel", 1:100),
+      varlabels = character(0),
       keys = character(0)
     )$format(indent = "wrong type"),
     regexp = "Assertion on 'indent' failed: Must be of type 'number'"
@@ -314,7 +325,7 @@ testthat::test_that("$format() concatenates its FilterState elements using \\n a
     input_dataname = "test",
     output_dataname = "test_filtered",
     datalabel = character(0),
-    varlabels = paste0("varlabel", 1:100),
+    varlabels = character(0),
     keys = character(0)
   )
 

--- a/tests/testthat/test-MAEFilterStates.R
+++ b/tests/testthat/test-MAEFilterStates.R
@@ -3,7 +3,7 @@ testthat::test_that("The constructor does not throw", {
     input_dataname = "test",
     output_dataname = "test",
     datalabel = character(0),
-    varlabels = "varblabel1",
+    varlabels = "varlabel1",
     keys = character(0)
   ), NA)
 })


### PR DESCRIPTION
# Pull Request

Fixes #[271](https://github.com/insightsengineering/teal.modules.hermes/issues/271)


It looks like a mistake done while copying:
https://github.com/insightsengineering/teal.slice/blob/09c6ab2e026325b62c790c3759ac414701457a62/R/FilterStates.R#L1077

double operator does not make sense here for me on line 1456.

Anyway, warning was produced because of: https://stackoverflow.com/questions/72848442/r-warning-lengthx-2-1-in-coercion-to-logical1/72848495#72848495 which came with R >= 4.2
