### PR TITLE
Fix rounding for pretty formatting of sliderInput steps

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,4 @@
-linters: with_defaults(
+linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
   cyclocomp_linter = NULL,
   object_usage_linter = NULL

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 ### Bug fixes
 
 * Fixed a bug when the filter panel overview would not refresh if the panel was hidden during a transition between active modules.
+* Fixed a bug in `FilterState` where `sliderInput` step values were too precise.
 
 # teal.slice 0.1.1
 

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -1662,11 +1662,34 @@ RangeFilterState <- R6::R6Class( # nolint
     # @return numeric(3) with names min, max, step - relevant for sliderInput
     get_pretty_range_inputs = function(values) {
       v_pretty_range <- pretty(values, n = 100)
+      min <- min(v_pretty_range)
+      max <- max(v_pretty_range)
+
+      step <- private$get_pretty_range_step(min, max, v_pretty_range)
+
       c(
-        min = v_pretty_range[1],
-        max = v_pretty_range[length(v_pretty_range)],
-        step = `if`(private$is_integer, 1L, v_pretty_range[2] - v_pretty_range[1])
+        min = min,
+        max = max,
+        step = step
       )
+    },
+    # @description gets pretty step size for range slider
+    #  adaptation of shiny's method (see shiny/R/input-slider.R function findStepSize)
+    # @param min (numeric) minimum of pretty values
+    # @param max (numeric) maximum of pretty values
+    # @param pretty_range (numeric(n)) vector of pretty values
+    # @return numeric(1) pretty step size for the sliderInput
+    get_pretty_range_step = function(min, max, pretty_range) {
+      range <- max - min
+
+      if (private$is_integer && range > 2) {
+        return(1L)
+      } else {
+        n_steps <- length(pretty_range) - 1
+        return(
+          signif(digits = 10, (max - min) / n_steps)
+        )
+      }
     },
     validate_selection = function(value) {
       if (!is.numeric(value)) {

--- a/tests/testthat/test-FilterState.R
+++ b/tests/testthat/test-FilterState.R
@@ -273,7 +273,6 @@ testthat::test_that("private$get_pretty_range_step returns pretty step size", {
     pretty_mpg
   )
   testthat::expect_identical(step, 0.2)
-
 })
 
 testthat::test_that("private$get_pretty_range_inputs returns nicely rounded values", {
@@ -296,6 +295,4 @@ testthat::test_that("private$get_pretty_range_inputs returns nicely rounded valu
   pretty_vals <- filter_state$test_get_pretty_range_inputs(mtcars$mpg)
   expected_vals <- c(min = 10.4, max = 34, step = 0.2)
   testthat::expect_identical(pretty_vals, expected_vals)
-
 })
-

--- a/tests/testthat/test-FilterState.R
+++ b/tests/testthat/test-FilterState.R
@@ -240,3 +240,62 @@ testthat::test_that("$format() prepends spaces to every line of the returned str
     )
   }
 })
+
+
+# bug fix #41
+testthat::test_that("private$get_pretty_range_step returns pretty step size", {
+  test_class <- R6::R6Class(
+    classname = "TestClass",
+    inherit = RangeFilterState,
+    public = list(
+      test_get_pretty_range_step = function(min, max, pretty_range) {
+        private$get_pretty_range_step(min, max, pretty_range)
+      }
+    )
+  )
+
+  pretty_sepal_length <- pretty(iris$Sepal.Length, n = 100)
+
+  filter_state <- test_class$new(pretty_sepal_length, varname = "test")
+  step <- filter_state$test_get_pretty_range_step(
+    min(pretty_sepal_length),
+    max(pretty_sepal_length),
+    pretty_sepal_length
+  )
+  testthat::expect_identical(step, 0.05)
+
+  pretty_mpg <- pretty(mtcars$mpg, n = 100)
+
+  filter_state <- test_class$new(pretty_mpg, varname = "test")
+  step <- filter_state$test_get_pretty_range_step(
+    min(pretty_mpg),
+    max(pretty_mpg),
+    pretty_mpg
+  )
+  testthat::expect_identical(step, 0.2)
+
+})
+
+testthat::test_that("private$get_pretty_range_inputs returns nicely rounded values", {
+  test_class <- R6::R6Class(
+    classname = "TestClass",
+    inherit = RangeFilterState,
+    public = list(
+      test_get_pretty_range_inputs = function(values) {
+        private$get_pretty_range_inputs(values)
+      }
+    )
+  )
+
+  filter_state <- test_class$new(iris$Sepal.Length, varname = "test")
+  pretty_vals <- filter_state$test_get_pretty_range_inputs(iris$Sepal.Length)
+  expected_vals <- c(min = 4.30, max = 7.90, step = 0.05)
+  testthat::expect_equal(pretty_vals, expected_vals, tolerance = 0.01)
+
+  filter_state <- test_class$new(mtcars$mpg, varname = "test")
+  pretty_vals <- filter_state$test_get_pretty_range_inputs(mtcars$mpg)
+  expected_vals <- c(min = 10.4, max = 34, step = 0.2)
+  testthat::expect_identical(pretty_vals, expected_vals)
+
+})
+


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #41. 

This PR implements nicer displayed numbers for slider inputs. It uses essentially the [same method as Shiny](https://github.com/rstudio/shiny/blob/c21ba0baca5a3eeaeabbdbcb8e9e83a6bd9a0bb9/R/input-slider.R#L255-L274).
