### PR TITLE
change formatting of selected values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: teal.slice
 Title: Filter Module for `teal` Applications
-Version: 0.1.1.9021
-Date: 2022-10-12
+Version: 0.2.0
+Date: 2022-10-14
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),
     person("Pawel", "Rucki", , "pawel.rucki@roche.com", role = "aut"),
@@ -31,17 +31,17 @@ Imports:
     shinyjs,
     shinyWidgets (>= 0.5.0),
     stats,
-    teal.data (>= 0.1.1),
-    teal.logger (>= 0.1.0),
-    teal.widgets (>= 0.1.1)
+    teal.data (>= 0.1.2),
+    teal.logger (>= 0.1.1),
+    teal.widgets (>= 0.2.0)
 Suggests:
     bslib,
     formatters (>= 0.3.1),
     knitr,
     MultiAssayExperiment,
     rmarkdown,
-    scda (>= 0.1.3),
-    scda.2021 (>= 0.1.3),
+    scda (>= 0.1.5),
+    scda.2021 (>= 0.1.5),
     SummarizedExperiment,
     testthat (>= 2.0),
     utils,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: teal.slice
 Title: Filter Module for `teal` Applications
-Version: 0.1.1.9020
-Date: 2022-10-10
+Version: 0.1.1.9021
+Date: 2022-10-12
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),
     person("Pawel", "Rucki", , "pawel.rucki@roche.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.slice 0.1.1.9021
+# teal.slice 0.2.0
 
 ### New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.slice 0.1.1.9020
+# teal.slice 0.1.1.9021
 
 ### New features
 

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -370,7 +370,8 @@ FilterState <- R6::R6Class( # nolint
         strwrap(sprintf("Filtering on: %s", self$get_varname(deparse = TRUE)), indent = indent),
         # Add wrapping and progressive indent to values enumeration as it is likely to be long.
         strwrap(sprintf("Selected values: %s", values),
-                width = 76, indent = indent + 2, exdent = indent + 4),
+          width = 76, indent = indent + 2, exdent = indent + 4
+        ),
         strwrap(sprintf("Include missing values: %s", self$get_keep_na()), indent = indent + 2)
       ), collapse = "\n")
     },

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -2168,30 +2168,32 @@ DateFilterState <- R6::R6Class( # nolint
     #'  id of shiny element
     ui = function(id) {
       ns <- NS(id)
-      fluidRow(
+      div(
         div(
+          class = "flex",
           actionButton(
-            class = "start_date_reset_button",
+            class = "date_reset_button",
             inputId = ns("start_date_reset"),
             label = NULL,
             icon = icon("fas fa-undo")
           ),
-          actionButton(
-            class = "end_date_reset_button",
-            inputId = ns("end_date_reset"),
-            label = NULL,
-            icon = icon("fas fa-undo")
-          ),
           div(
-            class = "m-auto w-80",
+            class = "w-80 filter_datelike_input",
             dateRangeInput(
               inputId = ns("selection"),
               label = NULL,
               start = isolate(self$get_selected())[1],
               end = isolate(self$get_selected())[2],
               min = private$choices[1],
-              max = private$choices[2]
+              max = private$choices[2],
+              width = "100%"
             )
+          ),
+          actionButton(
+            class = "date_reset_button",
+            inputId = ns("end_date_reset"),
+            label = NULL,
+            icon = icon("fas fa-undo")
           )
         ),
         if (private$na_count > 0) {
@@ -2495,8 +2497,8 @@ DatetimeFilterState <- R6::R6Class( # nolint
             icon = icon("fas fa-undo")
           ),
           div(
-            class = "flex w-80 air_datepicker_input",
-            div(class = "w-45", {
+            class = "flex w-80 filter_datelike_input",
+            div(class = "w-45 text-center", {
               x <- shinyWidgets::airDatepickerInput(
                 inputId = ns("selection_start"),
                 value = isolate(self$get_selected())[1],
@@ -2512,11 +2514,11 @@ DatetimeFilterState <- R6::R6Class( # nolint
               x
             }),
             span(
-              class = "w-10 air_datapicker_input_help",
-              "to",
+              class = "input-group-addon w-10",
+              span(class = "input-group-text w-100 justify-content-center", "to"),
               title = "Times are displayed in the local timezone and are converted to UTC in the analysis"
             ),
-            div(class = "w-45", {
+            div(class = "w-45 text-center", {
               x <- shinyWidgets::airDatepickerInput(
                 inputId = ns("selection_end"),
                 value = isolate(self$get_selected())[2],

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -40,6 +40,10 @@
   margin-bottom: 1rem;
 }
 
+.justify-content-center {
+  justify-content: center;
+}
+
 .date_reset_button {
   padding: 0;
   padding-top: 4px;
@@ -48,15 +52,18 @@
   height: 3rem;
 }
 
-span.air_datapicker_input_help {
-  text-align: center;
-  background-color: #dee2e6;
-  padding: 0.5rem 0;
-  height: 3rem;
+.filter_datelike_input input {
+  height: 3rem !important;
+  text-align: center !important;
+  font-size: 1rem !important;
 }
 
-.air_datepicker_input input {
-  height: 3rem;
+.filter_datelike_input span.input-group-text {
+  height: 3rem !important;
+}
+
+.filter_datelike_input span.input-group-addon {
+  height: 3rem !important;
 }
 
 .no-left-right-padding {

--- a/tests/testthat/test-FilterState.R
+++ b/tests/testthat/test-FilterState.R
@@ -246,7 +246,7 @@ testthat::test_that("$format() returns a properly wrapped string", {
   filter_state$set_state(list(selected = c(7, 7)))
   for (i in 1:10) {
     line_width <- 76L # arbitrary value given in method body
-    manual <- 4L      # manual third order indent given in method body
+    manual <- 4L # manual third order indent given in method body
     output <- shiny::isolate(filter_state$format(indent = i))
     captured <- utils::capture.output(cat(output))
     line_lengths <- vapply(captured, nchar, length(1L))


### PR DESCRIPTION
# Pull Request

solves this issue:
https://github.com/insightsengineering/teal.slice/issues/109

- set `format(justify = "none") to avoid extra whitespace
- values are comma-separated
- lines are wrapped
