### PR TITLE
fix date filter input

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -2514,8 +2514,8 @@ DatetimeFilterState <- R6::R6Class( # nolint
               x
             }),
             span(
-              class = "w-10 input-group-addon",
-              span(class = "input-group-text w-100", "to"),
+              class = "input-group-addon w-10",
+              span(class = "input-group-text w-100 justify-content-center", "to"),
               title = "Times are displayed in the local timezone and are converted to UTC in the analysis"
             ),
             div(class = "w-45", {

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -2168,30 +2168,32 @@ DateFilterState <- R6::R6Class( # nolint
     #'  id of shiny element
     ui = function(id) {
       ns <- NS(id)
-      fluidRow(
+      div(
         div(
+          class = "flex",
           actionButton(
-            class = "start_date_reset_button",
+            class = "date_reset_button",
             inputId = ns("start_date_reset"),
             label = NULL,
             icon = icon("fas fa-undo")
           ),
-          actionButton(
-            class = "end_date_reset_button",
-            inputId = ns("end_date_reset"),
-            label = NULL,
-            icon = icon("fas fa-undo")
-          ),
           div(
-            class = "m-auto w-80",
+            class = "w-80 filter_datelike_input",
             dateRangeInput(
               inputId = ns("selection"),
               label = NULL,
               start = isolate(self$get_selected())[1],
               end = isolate(self$get_selected())[2],
               min = private$choices[1],
-              max = private$choices[2]
+              max = private$choices[2],
+              width = "100%"
             )
+          ),
+          actionButton(
+            class = "date_reset_button",
+            inputId = ns("end_date_reset"),
+            label = NULL,
+            icon = icon("fas fa-undo")
           )
         ),
         if (private$na_count > 0) {
@@ -2495,7 +2497,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
             icon = icon("fas fa-undo")
           ),
           div(
-            class = "flex w-80 air_datepicker_input",
+            class = "flex w-80 filter_datelike_input",
             div(class = "w-45", {
               x <- shinyWidgets::airDatepickerInput(
                 inputId = ns("selection_start"),
@@ -2512,8 +2514,8 @@ DatetimeFilterState <- R6::R6Class( # nolint
               x
             }),
             span(
-              class = "w-10 air_datapicker_input_help",
-              "to",
+              class = "w-10 input-group-addon",
+              span(class = "input-group-text w-100", "to"),
               title = "Times are displayed in the local timezone and are converted to UTC in the analysis"
             ),
             div(class = "w-45", {

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -2498,7 +2498,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
           ),
           div(
             class = "flex w-80 filter_datelike_input",
-            div(class = "w-45", {
+            div(class = "w-45 text-center", {
               x <- shinyWidgets::airDatepickerInput(
                 inputId = ns("selection_start"),
                 value = isolate(self$get_selected())[1],
@@ -2518,7 +2518,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
               span(class = "input-group-text w-100 justify-content-center", "to"),
               title = "Times are displayed in the local timezone and are converted to UTC in the analysis"
             ),
-            div(class = "w-45", {
+            div(class = "w-45 text-center", {
               x <- shinyWidgets::airDatepickerInput(
                 inputId = ns("selection_end"),
                 value = isolate(self$get_selected())[2],

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -54,7 +54,8 @@
 
 .filter_datelike_input input {
   height: 3rem !important;
-  text-align: center;
+  text-align: center !important;
+  font-size: 1rem !important;
 }
 
 .filter_datelike_input span.input-group-text {

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -40,6 +40,10 @@
   margin-bottom: 1rem;
 }
 
+.justify-content-center {
+  justify-content: center;
+}
+
 .date_reset_button {
   padding: 0;
   padding-top: 4px;

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -48,15 +48,16 @@
   height: 3rem;
 }
 
-span.air_datapicker_input_help {
-  text-align: center;
-  background-color: #dee2e6;
-  padding: 0.5rem 0;
-  height: 3rem;
+.filter_datelike_input input {
+  height: 3rem !important;
 }
 
-.air_datepicker_input input {
-  height: 3rem;
+.filter_datelike_input span.input-group-text {
+  height: 3rem !important;
+}
+
+.filter_datelike_input span.input-group-addon {
+  height: 3rem !important;
 }
 
 .no-left-right-padding {

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -54,6 +54,7 @@
 
 .filter_datelike_input input {
   height: 3rem !important;
+  text-align: center;
 }
 
 .filter_datelike_input span.input-group-text {


### PR DESCRIPTION
closes #111 

Fix the styling of the Date filter input.
It is very important to test it for all 3 bootstrap versions, and for date and datetime inputs at the same time.

```r
options("teal.bs_theme" = bslib::bs_theme(version = "3"))
teal.gallery::launch_app("exploratory")
options("teal.bs_theme" = bslib::bs_theme(version = "4"))
teal.gallery::launch_app("exploratory")
options("teal.bs_theme" = bslib::bs_theme(version = "5"))
teal.gallery::launch_app("exploratory")
```

Please remember about using shinyWidgets from main for version 3 and set up `options(shiny.useragg = FALSE)`.

<img width="1437" alt="Screenshot 2022-10-11 at 15 42 31" src="https://user-images.githubusercontent.com/10676545/195109556-0959b242-4bd0-4bc2-bfdc-f59f15860c04.png">
