### PR TITLE
white space formatting in filter state

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Updated the `get_varlabels` method for `FilterStates` classes. It now accepts a vector input.
 * Exported `S3` generic function `init_filter_states` so that it can be used in other packages.
 * Added a `FilterPanelAPI` class to encapsulate the API of a filter panel.
+* Improved filter state presentation in `FilterState$format`.
 
 ### Enhancements
 

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -364,13 +364,16 @@ FilterState <- R6::R6Class( # nolint
     format = function(indent = 0) {
       checkmate::assert_number(indent, finite = TRUE, lower = 0)
 
-      sprintf(
-        "%sFiltering on: %s\n%1$s  Selected values: %s\n%1$s  Include missing values: %s",
-        format("", width = indent),
-        self$get_varname(deparse = TRUE),
-        paste0(format(self$get_selected(), nsmall = 3), collapse = " "),
-        format(self$get_keep_na())
-      )
+      # List all selected values separated by commas.
+      values <- paste(format(self$get_selected(), nsmall = 3, justify = "none"), collapse = ", ")
+      paste(c(
+        strwrap(sprintf("Filtering on: %s", self$get_varname(deparse = TRUE)), indent = indent),
+        # Add wrapping and progressive indent to values enumeration as it is likely to be long.
+        strwrap(sprintf("Selected values: %s", values),
+                width = 76, indent = indent + 2, exdent = indent + 4
+        ),
+        strwrap(sprintf("Include missing values: %s", self$get_keep_na()), indent = indent + 2)
+      ), collapse = "\n")
     },
 
     #' @description

--- a/tests/testthat/test-FilterState.R
+++ b/tests/testthat/test-FilterState.R
@@ -219,7 +219,7 @@ testthat::test_that("$format() returns a string representation the FilterState o
     shiny::isolate(filter_state$format(indent = 0)),
     paste(
       "Filtering on: test",
-      "  Selected values: 7.000 7.000",
+      "  Selected values: 7.000, 7.000",
       "  Include missing values: FALSE",
       sep = "\n"
     )
@@ -234,13 +234,25 @@ testthat::test_that("$format() prepends spaces to every line of the returned str
     testthat::expect_equal(
       shiny::isolate(filter_state$format(indent = !!(i))),
       sprintf(
-        "%sFiltering on: test\n%1$s  Selected values: 7.000 7.000\n%1$s  Include missing values: FALSE",
+        "%sFiltering on: test\n%1$s  Selected values: 7.000, 7.000\n%1$s  Include missing values: FALSE",
         format("", width = i)
       )
     )
   }
 })
 
+testthat::test_that("$format() returns a properly wrapped string", {
+  filter_state <- FilterState$new(c(7), varname = "test")
+  filter_state$set_state(list(selected = c(7, 7)))
+  for (i in 1:10) {
+    line_width <- 76L # arbitrary value given in method body
+    manual <- 4L # manual third order indent given in method body
+    output <- shiny::isolate(filter_state$format(indent = i))
+    captured <- utils::capture.output(cat(output))
+    line_lengths <- vapply(captured, nchar, length(1L))
+    testthat::expect_lte(max(line_lengths), line_width + i + manual)
+  }
+})
 
 # bug fix #41
 testthat::test_that("private$get_pretty_range_step returns pretty step size", {


### PR DESCRIPTION
Solves [this issue](https://github.com/insightsengineering/teal.slice/issues/109). Items are enumerated with comma separation and lines are wrapped at ~80 characters.

