### PR TITLE
fix range slider

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -393,6 +393,7 @@ FilterState <- R6::R6Class( # nolint
     ui = function(id) {
       ns <- NS(id)
       fluidPage(
+        include_css_files(pattern = "filter-panel"),
         theme = get_teal_bs_theme(),
         fluidRow(
           column(


### PR DESCRIPTION
On main the app below causes problems with the slider

If you move the left edge of the slider away from 0 and then back to 0 it will jump out to 0.01 which is confusing.
This PR fixes this issue (and also adds the css into FilterState ui function so the histogram is in the correct position).

Please test with this app but also other apps and values of the range to make sure this hasn't caused unforeseen issues.

Once merged in this can be merged into filter panel refactor branch

```
library(shiny)
library(teal.slice)
library(shinyjs)

x <- c(0.0091, 0.01 + runif(50, max= 0.99))

my_filter_state <- teal.slice:::init_filter_state(
  x = x,
  varname = "VARNAME",
  varlabel = "A label"
)

#####

ui <- fluidPage(
  useShinyjs(),
  column(3,
         div(  # only need a div so that we can hide the ui when the close button is pressed
           id = "x",
           my_filter_state$ui("fs"),
           h4("Condition (i.e. call)"), # show the condition generated by this FilterState
           textOutput("condition"),
           h4("Formatted state"), # show the human readable state
           textOutput("formatted"),
           h4("Unformatted state"), # show the raw state
           textOutput("unformatted"),
         )
  )
)

server <- function(input, output, session) {

  output$condition <- renderPrint(my_filter_state$get_call())
  output$formatted <- renderText(my_filter_state$format())
  output$unformatted <- renderPrint(my_filter_state$get_state()) # also get_selected(), get_keep_na

  signal_to_remove <- my_filter_state$server("fs")  # filterstate$server returns a trigger when the close button is pressed
  observeEvent(signal_to_remove(), shinyjs::hide("x")) # and shinyjs removes the ui
}

shinyApp(ui, server)

```

