### PR TITLE
start and end date validation in filter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,11 +18,13 @@
 
 * Fixed an error where the `RangeFilterState` produced an error when using `bootstrap 4`.
 * Fixed a bug that caused the range slider to omit values selected programmatically through the filter API.
+* Fixed a bug where setting incorrect values for Date / Datetime ranges caused the app to crash.
 
 ### Miscellaneous
 
 * Calculation of step in slider for `RangeFilterState` now uses `checkmate::test_integerish` instead of `is.integer`.
 * Updated `init_filtered_data` to take into account the removal of `CDISCTealData` from `teal.data` package.
+* Added `shinyvalidate` validation for Date / Datetime ranges.
 
 # teal.slice 0.2.0
 

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -169,20 +169,32 @@ DateFilterState <- R6::R6Class( # nolint
       values
     },
     remove_out_of_bound_values = function(values) {
-      if (values[1] < private$choices[1]) {
-        warning(paste(
-          "Value:", values[1], "is outside of the possible range for column", private$varname,
-          "of dataset", private$dataname, "."
-        ))
+      if (values[1] < private$choices[1] | values[1] > private$choices[2]) {
+        warning(
+          sprintf(
+            "Value: %s is outside of the possible range for column %s of dataset %s, setting minimum possible value.",
+            values[1], private$varname, private$dataname
+          ))
         values[1] <- private$choices[1]
       }
 
-      if (values[2] > private$choices[2]) {
-        warning(paste(
-          "Value:", values[2], "is outside of the possible range for column", private$varname,
-          "of dataset", private$dataname, "."
-        ))
+      if (values[2] > private$choices[2] | values[2] < private$choices[1]) {
+        warning(
+          sprintf(
+            "Value: %s is outside of the possible range for column %s of dataset %s, setting maximum possible value.",
+            values[2], private$varname, private$dataname
+          )
+        )
         values[2] <- private$choices[2]
+      }
+
+      if (values[1] > values[2]) {
+        warning(
+          sprintf(
+            "Start date %s is set after the end date %s, the values will be replaced.",
+            values[1], values[2])
+        )
+        values <- c(min(values), max(values))
       }
       values
     },
@@ -275,7 +287,7 @@ DateFilterState <- R6::R6Class( # nolint
               iv <- shinyvalidate::InputValidator$new()
               iv$add_rule("selection", ~ if (
                 start_date > end_date
-              ) "Start date must not be greater than the end date!")
+              ) "Start date must not be greater than the end date.")
               iv$enable()
               teal::validate_inputs(iv)
 

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -192,7 +192,7 @@ DateFilterState <- R6::R6Class( # nolint
       if (values[1] > values[2]) {
         warning(
           sprintf(
-            "Start date %s is set after the end date %s, the values will be replaced.",
+            "Start date %s is set after the end date %s, the values will be replaced with a default date range.",
             values[1], values[2])
         )
         values <- c(min(values), max(values))

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -272,6 +272,13 @@ DateFilterState <- R6::R6Class( # nolint
               start_date <- input$selection[1]
               end_date <- input$selection[2]
 
+              iv <- shinyvalidate::InputValidator$new()
+              iv$add_rule("selection", ~ if (
+                start_date > end_date
+              ) "Start date must not be greater than the end date!")
+              iv$enable()
+              teal::validate_inputs(iv)
+
               self$set_selected(c(start_date, end_date))
               logger::log_trace(sprintf(
                 "DateFilterState$server@2 selection of variable %s changed, dataname: %s",

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -174,7 +174,8 @@ DateFilterState <- R6::R6Class( # nolint
           sprintf(
             "Value: %s is outside of the possible range for column %s of dataset %s, setting minimum possible value.",
             values[1], private$varname, private$dataname
-          ))
+          )
+        )
         values[1] <- private$choices[1]
       }
 

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -195,7 +195,7 @@ DateFilterState <- R6::R6Class( # nolint
             "Start date %s is set after the end date %s, the values will be replaced with a default date range.",
             values[1], values[2])
         )
-        values <- c(min(values), max(values))
+        values <- c(private$choices[1], private$choices[2])
       }
       values
     },

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -192,7 +192,8 @@ DatetimeFilterState <- R6::R6Class( # nolint
           sprintf(
             "Value: %s is outside of the possible range for column %s of dataset %s, setting minimum possible value.",
             values[1], private$varname, private$dataname
-        ))
+          )
+        )
         values[1] <- private$choices[1]
       }
 

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -187,20 +187,33 @@ DatetimeFilterState <- R6::R6Class( # nolint
       values
     },
     remove_out_of_bound_values = function(values) {
-      if (values[1] < private$choices[1]) {
-        warning(paste(
-          "Value:", values[1], "is outside of the possible range for column", private$varname,
-          "of dataset", private$dataname, "."
+      if (values[1] < private$choices[1] | values[1] > private$choices[2]) {
+        warning(
+          sprintf(
+            "Value: %s is outside of the possible range for column %s of dataset %s, setting minimum possible value.",
+            values[1], private$varname, private$dataname
         ))
         values[1] <- private$choices[1]
       }
 
-      if (values[2] > private$choices[2]) {
-        warning(paste(
-          "Value:", values[2], "is outside of the possible range for column", private$varname,
-          "of dataset", private$dataname, "."
-        ))
+      if (values[2] > private$choices[2] | values[2] < private$choices[1]) {
+        warning(
+          sprintf(
+            "Value: %s is outside of the possible range for column %s of dataset %s, setting maximum possible value.",
+            values[2], private$varname, private$dataname
+          )
+        )
         values[2] <- private$choices[2]
+      }
+
+      if (values[1] > values[2]) {
+        warning(
+          sprintf(
+            "Start date %s is set after the end date %s, the values will be replaced.",
+            values[1], values[2]
+          )
+        )
+        values <- c(min(values), max(values))
       }
       values
     },
@@ -340,10 +353,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
               iv <- shinyvalidate::InputValidator$new()
               iv$add_rule("selection_start", ~ if (
                 input$selection_start > input$selection_end
-              ) "Start date must not be greater...")
-              iv$add_rule("selection_end", ~ if (
-                input$selection_start > input$selection_end
-              ) "...than the end date!")
+              ) "Start date must not be greater than the end date.")
               iv$enable()
               teal::validate_inputs(iv)
 

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -214,7 +214,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
             values[1], values[2]
           )
         )
-        values <- c(min(values), max(values))
+        values <- c(private$choices[1], private$choices[2])
       }
       values
     },

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -210,7 +210,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
       if (values[1] > values[2]) {
         warning(
           sprintf(
-            "Start date %s is set after the end date %s, the values will be replaced.",
+            "Start date %s is set after the end date %s, the values will be replaced with a default datetime range.",
             values[1], values[2]
           )
         )

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -64,10 +64,6 @@ DatetimeFilterState <- R6::R6Class( # nolint
       private$set_choices(var_range)
       self$set_selected(var_range)
 
-      if (var_range[1] > var_range[2]) {
-        stop("fubar")
-      }
-
       if (shiny::isRunning()) {
         session <- getDefaultReactiveDomain()
         if (!is.null(session$userData$timezone)) {


### PR DESCRIPTION
# Pull Request

Fixes #[158](https://github.com/insightsengineering/teal.slice/issues/158)


1. At initialization, when values are not valid, corrections will be performed with warnings.
2. Later, when changed by the user, shinyvalidate is used.
 
Example to test:

```
adsl <- synthetic_cdisc_dataset("latest", "adsl")

app <- init(
  data = teal_data(dataset("ADSL", adsl)),
  modules = example_module(),
  filter = list(
    "ADSL" = list(
      RANDDT = list(selected = c("2021-02-16", "2021-02-17")),
      TRT01SDTM = list(selected = c("2021-02-11 17:09:18", "2021-02-10 20:42:27"))
    )
  )
)
runApp(app)
```
