### PR TITLE
fix for warnings and errors in test due to values comparison

### DIFF
--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -105,7 +105,7 @@ RangeFilterState <- R6::R6Class( # nolint
     #' Answers the question of whether the current settings and values selected actually filters out any values.
     #' @return logical scalar
     is_any_filtered = function() {
-      if (!setequal(self$get_selected(), private$choices)) {
+      if (!isTRUE(all.equal(self$get_selected(), private$choices))) {
         TRUE
       } else if (!isTRUE(self$get_keep_inf()) && private$inf_count > 0) {
         TRUE
@@ -276,7 +276,7 @@ RangeFilterState <- R6::R6Class( # nolint
       if (length(values) != 2) stop("The array of set values must have length two.")
 
       values_adjusted <- contain_interval(values, private$slider_ticks)
-      if (!identical(values, values_adjusted)) {
+      if (!all.equal(values, values_adjusted)) {
         logger::log_warn(sprintf(
           paste(
             "Programmatic range specification on %s was adjusted to existing slider ticks.",


### PR DESCRIPTION
# Pull Request

I noticed warnings (`Programmatic range specification on `) and errors in `teal.slice` tests on main coming from `FilterStateRange.R`, solved with @chlebowa 

It was due to the fact that we used `identical` / `setequal` for comparisons of double turned from integers with double etc..

