### PR TITLE
Expand card click are

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -626,21 +626,18 @@ InteractiveFilterState <- R6::R6Class( # nolint
         class = "panel panel-default",
         include_js_files("count-bar-labels.js"),
         tags$div(
-          class = "panel-heading",
+          class = "panel-heading accordion-toggle",
+          `data-toggle` = "collapse",
+          `data-parent` = paste0("#", parent_id),
+          href = paste0("#", ns("body")),
           tags$div(
             class = "panel-title",
-            tags$a(
-              class = "accordion-toggle",
-              `data-toggle` = "collapse",
-              `data-parent` = paste0("#", parent_id),
-              href = paste0("#", ns("body")),
               tags$span(tags$strong(self$get_varname())),
               if (length(self$get_varlabel())) {
                 tags$span(self$get_varlabel(), class = "filter-card-varlabel")
               } else {
                 NULL
-              }
-            ),
+              },
             actionLink(
               inputId = ns("remove"),
               label = icon("circle-xmark", lib = "font-awesome"),
@@ -672,21 +669,18 @@ InteractiveFilterState <- R6::R6Class( # nolint
         class = "card",
         include_js_files("count-bar-labels.js"),
         tags$div(
-          class = "card-header",
+          class = "card-header accordion-toggle",
+          `data-toggle` = "collapse",
+          `data-bs-toggle` = "collapse",
+          href = paste0("#", ns("body")),
           tags$div(
             class = "card-title",
-            tags$a(
-              class = "accordion-toggle",
-              `data-toggle` = "collapse",
-              `data-bs-toggle` = "collapse",
-              href = paste0("#", ns("body")),
               tags$span(tags$strong(self$get_varname())),
               if (length(self$get_varlabel())) {
                 tags$span(self$get_varlabel(), class = "filter-card-varlabel")
               } else {
                 NULL
-              }
-            ),
+              },
             actionLink(
               inputId = ns("remove"),
               label = icon("circle-xmark", lib = "font-awesome"),

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -222,12 +222,12 @@ a.remove_all:hover {
 .panel-title,
 .card-title {
   display: flex;
-  justify-content: space-between;
 }
 
 .panel-title a,
 .card-title a {
   text-decoration: none;
+  margin-left: auto;
 }
 
 .card-title a {
@@ -240,6 +240,7 @@ a.remove_all:hover {
 
 .filter-card-varlabel {
  color: var(--bs-gray-500, var(--gray, darkgray));
+ margin-left: 0.5em;
 }
 
 .filter-card-remove,


### PR DESCRIPTION
Expands the clickable area of filter cards so they expand/collapse when clicking anywhere in the card header. (except remove icon)

Closes #203
