### PR TITLE
Let numeric input be set manually

### DIFF
--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -176,6 +176,10 @@ a.remove_all:hover {
   max-width: 100%;
 }
 
+.keep_na_inf {
+  display: flex;
+  justify-content: space-evenly;
+}
 
 .filter_panel_dataname {
   font-weight: bold;


### PR DESCRIPTION
Let's a numeric input be set via range slider or input boxes.

- Only one type, slider or input box, is available at a time.
- Which is visible is controlled by a checkbox.
- When switching input types, the new input gets set to the values of the old input.

Closes #133