### PR TITLE
Initialize FilterState based on count type

### DIFF
--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -398,7 +398,11 @@ ChoicesFilterState <- R6::R6Class( # nolint
       ns <- NS(id)
 
       countsmax <- private$choices_counts
-      countsnow <- isolate(unname(table(factor(private$x_reactive(), levels = private$choices))))
+      countsnow <- if (!is.null(private$x_reactive())) {
+        isolate(unname(table(factor(private$x_reactive(), levels = private$choices))))
+      } else {
+        NULL
+      }
 
       ui_input <- if (private$is_checkboxgroup()) {
         labels <- countBars(
@@ -467,19 +471,26 @@ ChoicesFilterState <- R6::R6Class( # nolint
               private$varname,
               private$dataname
             ))
+
+            countsnow <- if (!is.null(private$x_reactive())) {
+              unname(table(factor(non_missing_values(), levels = private$choices)))
+            } else {
+              NULL
+            }
+
             if (private$is_checkboxgroup()) {
               updateCountBars(
                 inputId = "labels",
                 choices = private$choices,
                 countsmax = private$choices_counts,
-                countsnow = unname(table(factor(non_missing_values(), levels = private$choices)))
+                countsnow = countsnow
               )
             } else {
               labels <- mapply(
                 FUN = make_count_text,
                 label = private$choices,
                 countmax = private$choices_counts,
-                countnow = unname(table(factor(non_missing_values(), levels = private$choices)))
+                countnow = countsnow
               )
               teal.widgets::updateOptionalSelectInput(
                 session = session,

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -283,7 +283,11 @@ LogicalFilterState <- R6::R6Class( # nolint
       ns <- NS(id)
 
       countsmax <- private$choices_counts
-      countsnow <- isolate(unname(table(factor(private$x_reactive(), levels = private$choices))))
+      countsnow <- countsnow <- if (!is.null(private$x_reactive())) {
+        isolate(unname(table(factor(private$x_reactive(), levels = private$choices))))
+      } else {
+        NULL
+      }
 
       labels <- countBars(
         inputId = ns("labels"),
@@ -329,11 +333,18 @@ LogicalFilterState <- R6::R6Class( # nolint
               private$varname,
               private$dataname
             ))
+
+            countsnow <- if (!is.null(private$x_reactive())) {
+              unname(table(factor(non_missing_values(), levels = private$choices)))
+            } else {
+              NULL
+            }
+
             updateCountBars(
               inputId = "labels",
               choices = as.character(private$choices),
               countsmax = private$choices_counts,
-              countsnow = unname(table(factor(non_missing_values(), levels = private$choices)))
+              countsnow = countsnow
             )
             NULL
           })

--- a/R/FilterStates-utils.R
+++ b/R/FilterStates-utils.R
@@ -61,7 +61,7 @@ init_filter_states <- function(data,
                                dataname,
                                datalabel = character(0),
                                excluded_varnames = character(0),
-                               count_type = c("none", "all", "hierarchical"),
+                               count_type = c("all", "none"),
                                ...) {
   UseMethod("init_filter_states")
 }
@@ -74,7 +74,7 @@ init_filter_states.data.frame <- function(data, # nolint
                                           datalabel = character(0),
                                           varlabels = character(0),
                                           excluded_varnames = character(0),
-                                          count_type = c("none", "all", "hierarchical"),
+                                          count_type = c("all", "none"),
                                           keys = character(0),
                                           ...) {
   DFFilterStates$new(
@@ -96,7 +96,7 @@ init_filter_states.matrix <- function(data, # nolint
                                       dataname,
                                       datalabel = character(0),
                                       excluded_varnames = character(0),
-                                      count_type = c("none", "all", "hierarchical"),
+                                      count_type = c("all", "none"),
                                       ...) {
   MatrixFilterStates$new(
     data = data,
@@ -116,7 +116,7 @@ init_filter_states.MultiAssayExperiment <- function(data, # nolint
                                                     datalabel = "patients",
                                                     varlabels = character(0),
                                                     excluded_varnames = character(0),
-                                                    count_type = c("none", "all", "hierarchical"),
+                                                    count_type = c("all", "none"),
                                                     keys = character(0),
                                                     ...) {
   if (!requireNamespace("MultiAssayExperiment", quietly = TRUE)) {
@@ -141,7 +141,7 @@ init_filter_states.SummarizedExperiment <- function(data, # nolint
                                                     dataname,
                                                     datalabel = character(0),
                                                     excluded_varnames = character(0),
-                                                    count_type = c("none", "all", "hierarchical"),
+                                                    count_type = c("all", "none"),
                                                     ...) {
   if (!requireNamespace("SummarizedExperiment", quietly = TRUE)) {
     stop("Cannot load SummarizedExperiment - please install the package or restart your session.")

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -71,7 +71,7 @@ FilterStates <- R6::R6Class( # nolint
                           dataname,
                           datalabel = character(0),
                           excluded_varnames = character(0),
-                          count_type = c("none", "all", "hierarchical")) {
+                          count_type = c("all", "none")) {
       checkmate::assert_function(data_reactive, args = "sid")
       checkmate::assert_string(dataname)
       checkmate::assert_character(datalabel, max.len = 1, any.missing = FALSE)

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -622,7 +622,11 @@ FilterStates <- R6::R6Class( # nolint
           # and this no longer needs to be a function to pass sid. reactive in the FilterState
           # is also beneficial as it can be cached and retriger filter counts only if
           # returned vector is different.
-          x_reactive = reactive(data_reactive(sid)[, x$varname, drop = TRUE]),
+          x_reactive = if (attr(state, "count_type") == "none") {
+            reactive(NULL)
+          } else {
+            reactive(data_reactive(sid)[, x$varname, drop = TRUE])
+          },
           extract_type = extract_type
         )
         arg_list <- append(arg_list, x)

--- a/R/FilterStatesDF.R
+++ b/R/FilterStatesDF.R
@@ -163,7 +163,7 @@ DFFilterStates <- R6::R6Class( # nolint
                           datalabel = character(0),
                           varlabels = character(0),
                           excluded_varnames = character(0),
-                          count_type = c("none", "all", "hierarchical"),
+                          count_type = c("all", "none"),
                           keys = character(0)) {
       checkmate::assert_function(data_reactive, args = "sid")
       checkmate::assert_data_frame(data)

--- a/R/FilterStatesMAE.R
+++ b/R/FilterStatesMAE.R
@@ -41,7 +41,7 @@ MAEFilterStates <- R6::R6Class( # nolint
                           datalabel = "subjects",
                           varlabels = character(0),
                           excluded_varnames = character(0),
-                          count_type = c("none", "all", "hierarchical"),
+                          count_type = c("all", "none"),
                           keys = character(0)) {
       if (!requireNamespace("MultiAssayExperiment", quietly = TRUE)) {
         stop("Cannot load MultiAssayExperiment - please install the package or restart your session.")

--- a/R/FilterStatesMatrix.R
+++ b/R/FilterStatesMatrix.R
@@ -35,7 +35,7 @@ MatrixFilterStates <- R6::R6Class( # nolint
                           dataname,
                           datalabel = character(0),
                           excluded_varnames = character(0),
-                          count_type = c("none", "all", "hierarchical")) {
+                          count_type = c("all", "none")) {
       checkmate::assert_function(data_reactive, args = "sid")
       checkmate::assert_matrix(data)
       super$initialize(data, data_reactive, dataname, datalabel, excluded_varnames, count_type)

--- a/R/FilterStatesSE.R
+++ b/R/FilterStatesSE.R
@@ -35,7 +35,7 @@ SEFilterStates <- R6::R6Class( # nolint
                           dataname,
                           datalabel = character(0),
                           excluded_varnames = character(0),
-                          count_type = c("none", "all", "hierarchical")) {
+                          count_type = c("all", "none")) {
       if (!requireNamespace("SummarizedExperiment", quietly = TRUE)) {
         stop("Cannot load SummarizedExperiment - please install the package or restart your session.")
       }

--- a/R/count_labels.R
+++ b/R/count_labels.R
@@ -71,7 +71,7 @@ countBars <- function(inputId, choices, countsmax, countsnow = NULL) { # nolint
     inputId = ns(seq_along(choices)),
     label = as.character(choices),
     countmax = countsmax,
-    countnow = countsnow,
+    countnow = if (is.null(countsnow)) rep(list(NULL), length(choices)) else countsnow,
     MoreArgs = list(
       counttotal = sum(countsmax)
     ),
@@ -101,6 +101,7 @@ countBar <- function(inputId, label, countmax, countnow = NULL, counttotal = cou
 
   label <- make_count_text(label, countmax = countmax, countnow = countnow)
   ns <- NS(inputId)
+  if (is.null(countnow)) countnow <- 0
   tags$div(
     class = "progress state-count-container",
     # * .9 to not exceed width of the parent html element
@@ -134,7 +135,7 @@ updateCountBars <- function(session = getDefaultReactiveDomain(), inputId, choic
     inputId = ns(seq_along(choices)),
     label = choices,
     countmax = countsmax,
-    countnow = countsnow,
+    countnow = if (is.null(countsnow)) rep(list(NULL), length(choices)) else countsnow,
     MoreArgs = list(
       counttotal = sum(countsmax)
     )
@@ -151,8 +152,8 @@ updateCountBar <- function(session = getDefaultReactiveDomain(), inputId, label,
   checkmate::assert_number(countnow, null.ok = TRUE)
   checkmate::assert_number(counttotal)
 
-  if (is.null(countnow)) countnow <- countmax
   label <- make_count_text(label, countmax = countmax, countnow = countnow)
+  if (is.null(countnow)) countnow <- countmax
   session$sendCustomMessage(
     type = "updateCountBar",
     message = list(

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -63,7 +63,12 @@
 #' @param exclude `named list` of `character` vectors where list names match names of data sets
 #'                 and vector elements match variable names in respective data sets;
 #'                 specifies which variables are not allowed to be filtered
-#' @param count_type `character(1)` string specifying how observations are tallied by these filter states
+#' @param count_type `character(1)` string specifying how observations are tallied by these filter states.
+#'  Possible options:
+#'  - `"all"` to have counts of single `FilterState` to show number of observation in filtered
+#'   and unfiltered dataset.
+#'  - `"none"` to have counts of single `FilterState` to show unfiltered number only.
+#'
 #' @param show_all `logical(1)` specifying whether NULL elements should also be printed
 #' @param tss `teal_slices`
 #' @param field `character(1)` name of `teal_slice` element
@@ -147,11 +152,12 @@ filter_var <- function(
 filter_settings <- function(
     ...,
     exclude = list(),
-    count_type = c("none", "all", "hierarchical")) {
+    count_type = c("all", "none")) {
   slices <- list(...)
   checkmate::assert_list(slices, types = "teal_slice", any.missing = FALSE)
   checkmate::assert_list(exclude, names = "named", types = "character")
   count_type <- match.arg(count_type)
+
 
   attr(slices, "exclude") <- exclude
   attr(slices, "count_type") <- count_type

--- a/man/calls_combine_by.Rd
+++ b/man/calls_combine_by.Rd
@@ -25,9 +25,9 @@ Combine list of calls by specific operator
 \examples{
 \dontrun{
 calls <- list(
-  quote(SEX == "F"),              # subsetting on factor
-  quote(AGE >= 20 & AGE <= 50),   # subsetting on range
-  quote(!SURV)                    # subsetting on logical
+  quote(SEX == "F"), # subsetting on factor
+  quote(AGE >= 20 & AGE <= 50), # subsetting on range
+  quote(!SURV) # subsetting on logical
 )
 calls_combine_by(calls, "&")
 }

--- a/man/filter_state_api.Rd
+++ b/man/filter_state_api.Rd
@@ -47,8 +47,10 @@ datasets <- init_filtered_data(
 fs <- filter_settings(
   filter_var("iris", "Species", selected = c("setosa", "versicolor")),
   filter_var("iris", "Sepal.Length", selected = c(5.1, 6.4)),
-  filter_var("mae", "years_to_birth", selected = c(30, 50),
-             keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", target = "y"),
+  filter_var("mae", "years_to_birth",
+    selected = c(30, 50),
+    keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", target = "y"
+  ),
   filter_var("mae", "vital_status", selected = "1", keep_na = FALSE, datalabel = "subjects", target = "y"),
   filter_var("mae", "gender", selected = "female", keep_na = TRUE, datalabel = "subjects", target = "y"),
   filter_var("mae", "ARRAY_TYPE", selected = "", keep_na = TRUE, datalabel = "RPPAArray", target = "subset")

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -34,7 +34,7 @@ filter_var(
 filter_settings(
   ...,
   exclude = list(),
-  count_type = c("none", "all", "hierarchical")
+  count_type = c("all", "none", "hierarchical")
 )
 
 is.teal_slice(x)
@@ -91,7 +91,14 @@ for other functions arguments passed to other methods}
 and vector elements match variable names in respective data sets;
 specifies which variables are not allowed to be filtered}
 
-\item{count_type}{\code{character(1)} string specifying how observations are tallied by these filter states}
+\item{count_type}{\code{character(1)} string specifying how observations are tallied by these filter states.
+Possible options:
+\itemize{
+\item \code{"all"} to have counts of single \code{FilterState} to show number of observation in filtered
+and unfiltered dataset.
+\item \code{"none"} to have counts of single \code{FilterState} to show unfiltered number only.
+\item \code{"hierarchical"} not implemented yet.
+}}
 
 \item{show_all}{\code{logical(1)} specifying whether NULL elements should also be printed}
 
@@ -162,8 +169,9 @@ for experiments and as "y" for \code{colData}.
 \examples{
 filter_1 <- filter_var("dataname1", "varname1", letters, "b", FALSE, extra1 = "extraone")
 filter_2 <- filter_var("dataname1", "varname2", 1:10, 2, TRUE, FALSE, extra2 = "extratwo")
-filter_3 <- filter_var("dataname2", "varname3", 1:10/10, 0.2, TRUE, FALSE,
-                       extra1 = "extraone", extra2 = "extratwo")
+filter_3 <- filter_var("dataname2", "varname3", 1:10 / 10, 0.2, TRUE, FALSE,
+  extra1 = "extraone", extra2 = "extratwo"
+)
 
 all_filters <- filter_settings(
   filter_1,

--- a/tests/testthat/test-teal_slice.R
+++ b/tests/testthat/test-teal_slice.R
@@ -109,7 +109,10 @@ testthat::test_that("filter_settings checks arguments", {
   testthat::expect_error(filter_settings(fs1, fs2, exclude = "fs1"), "Assertion on 'exclude' failed")
 
   testthat::expect_error(filter_settings(fs1, fs2, count_type = "fs1"), "'arg' should be")
-  testthat::expect_error(filter_settings(fs1, fs2, count_type = c("all", "none")), "'arg' must be of length 1")
+
+  testthat::expect_error(filter_settings(fs1, fs2, count_type = c("a", "b")), "'arg' must be of length 1")
+
+  testthat::expect_no_error(filter_settings(fs1, fs2, count_type = c("all", "none")))
 })
 
 
@@ -391,7 +394,7 @@ testthat::test_that("c.teal_slices handles attributes", {
   fs4 <- filter_var("data2", "var2")
   fss1 <- filter_settings(fs1, fs2, exclude = list(data1 = "var1"))
   fss2 <- filter_settings(fs3, fs4, exclude = list(data2 = "var1"))
-  fss3 <- filter_settings(fs3, fs4, exclude = list(data2 = "var1"), count_type = "all")
+  fss3 <- filter_settings(fs3, fs4, exclude = list(data2 = "var1"), count_type = "none")
 
   # teal_slices with different exclude attributes
   testthat::expect_no_error(c(fss1, fss2))
@@ -526,7 +529,7 @@ testthat::test_that("format.teal_slices prints count_type attribute", {
   fs2 <- filter_var("data", "var2")
   fs <- filter_settings(fs1, fs2)
   ffs <- format(fs, show_all = TRUE)
-  testthat::expect_true(grepl("count type: none", ffs))
+  testthat::expect_true(grepl("count type: all", ffs))
 })
 
 


### PR DESCRIPTION
If the `count_type` of a `teal_slices` object (`filter_settings`) is "none", then initialize `FilterState` objects with `x_reactive = reactive(NULL)`.

I feel like there's more that needs to be done but I don't know what. Am I missing something here?

@chlebowa most of the work for this you did with the API change so I think this is all that is needed here?

Fixes #188
