### PR TITLE
Update card summary design

### DIFF
--- a/R/FilterState-utils.R
+++ b/R/FilterState-utils.R
@@ -509,3 +509,121 @@ contain_interval <- function(x, range) {
   x[2] <- Find(function(i) i >= x[2], range, nomatch = max(range))
   x
 }
+
+
+#' Formats selected values of a RangeFilterState for display in the header summary.
+#'
+#' If a number has more significant digits than the threshhold, it will be
+#'  formatted in scientific notation. The resulting number will have 'threshold'
+#'  significant digits. If any `NA`s are present, they will be converted to the
+#'  character "NA". Similarly `Inf` and `-Inf` will be converted to the strings
+#'  "Inf" and "-Inf" respectively.
+#'
+#'
+#' @param values Vector of values to format. Can contain `NA`, `Inf`, `-Inf`.
+#' @param threshold Number of significant digits above which the number will be
+#'  formatted in scientific notation.
+#'
+#' @return Vector of `length(values)` as a string suitable for display.
+#' @keywords internal
+#' @noRd
+format_range_for_summary <- function(values, threshold = 4) {
+  checkmate::assert_numeric(values, min.len = 1)
+  checkmate::assert_number(threshold, lower = 1, finite = TRUE)
+
+  ops <- options(scipen = 9999)
+  on.exit(options(ops))
+
+  # convert to a string representation
+  values_str <- vapply(
+    values,
+    FUN.VALUE = character(1),
+    USE.NAMES = FALSE,
+    FUN = function(value) {
+      if (is.na(value) || is.finite(value)) {
+        format(value)
+      } else {
+        as.character(value)
+      }
+    })
+
+  n_digits <- n_sig_digits(values_str)
+
+  mapply(
+    values_str,
+    n_digits,
+    USE.NAMES = FALSE,
+    MoreArgs = list(threshold = threshold),
+    FUN = function(value, digits, threshold) {
+      if (digits == -1) { # special case for Inf, -Inf, NA
+        value
+      } else if (digits > threshold) {
+        val <- format(as.numeric(value), digits = threshold, scientific = TRUE)
+        val <- sub("e", "E", val)
+        val
+      } else {
+        value
+      }
+    }
+  )
+}
+
+#' Count the number of significant digits in a number.
+#'
+#' Adapted from https://www.r-bloggers.com/2010/04/significant-figures-in-r-and-info-zeros/
+#'  The supplied vector should be numbers represented as a character. `NA`, `Inf`,
+#'  and `-Inf` should be coded as the strings "NA", "Inf", and "-Inf". In these
+#'  cases, a count of -1 is returned.
+#'
+#' @param nums A vector of numbers that have been converted to character.
+#'
+#' @return Vector of `length(nums)` with counts of significant digits.
+#' @keywords internal
+#' @noRd
+n_sig_digits <- function(nums) {
+  checkmate::assert_character(nums, any.missing = FALSE)
+
+  vapply(nums, FUN.VALUE = numeric(1), USE.NAMES = FALSE, FUN = function(num) {
+
+    if (grepl("e", num)) return(-1)
+    if (num == "NA") return(-1)
+    if (num == "Inf" || num == "-Inf") return(-1)
+
+    sig_digits <- 1
+    i <- 0
+
+    if (grepl("\\.", num)) {
+
+      num_split <- unlist(strsplit(num, "\\."))
+      num_str <- paste(num_split[1], num_split[2], sep = "")
+      current_n_digits <- nchar(num_str)
+
+      while (i < current_n_digits) {
+
+        if (substr(num_str, i + 1, i + 1) == "0") {
+          i <- i + 1
+          next
+        } else {
+          sig_digits <- current_n_digits - i
+          break
+        }
+      }
+    } else {
+
+      num_str <- num
+      current_n_digits <- nchar(num_str)
+
+      while (i < current_n_digits) {
+        if (substr(num_str, current_n_digits - i, current_n_digits - i) == "0") {
+          i <- i + 1
+          next
+        } else {
+          sig_digits <- current_n_digits - i
+          break
+        }
+      }
+    }
+
+    return(sig_digits)
+  })
+}

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -585,8 +585,11 @@ ChoicesFilterState <- R6::R6Class( # nolint
     content_summary = function(id) {
       n_selected <- length(private$get_selected())
       tagList(
-        tags$span(sprintf("%s levels selected", n_selected)),
-        if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL
+        tags$span(sprintf("%s levels selected", n_selected), class = "filter-card-summary-value"),
+        tags$span(
+          class = "filter-card-summary-controls",
+          if (isTRUE(private$get_keep_na())) tags$span("NA", class = "filter-card-summary-na") else NULL
+        )
       )
     }
   )

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -585,7 +585,10 @@ ChoicesFilterState <- R6::R6Class( # nolint
     content_summary = function(id) {
       n_selected <- length(private$get_selected())
       tagList(
-        tags$span(sprintf("%s levels selected", n_selected), class = "filter-card-summary-value"),
+        tags$span(
+          class = "filter-card-summary-value",
+          paste0(private$get_selected(), collapse = ", ")
+        ),
         tags$span(
           class = "filter-card-summary-controls",
           if (isTRUE(private$get_keep_na()) && private$na_count > 0) {

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -588,7 +588,21 @@ ChoicesFilterState <- R6::R6Class( # nolint
         tags$span(sprintf("%s levels selected", n_selected), class = "filter-card-summary-value"),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na())) tags$span("NA", class = "filter-card-summary-na") else NULL
+          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("check")
+            )
+          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("xmark")
+            )
+          } else {
+            NULL
+          }
         )
       )
     }

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -583,11 +583,18 @@ ChoicesFilterState <- R6::R6Class( # nolint
     #  renders text describing number of selected levels
     #  and if NA are included also
     content_summary = function(id) {
-      n_selected <- length(private$get_selected())
+      selected <- private$get_selected()
+      selected_length <- nchar(paste0(selected, collapse = ""))
+      if (selected_length <= 40) {
+        selected_text <- paste0(selected, collapse = ", ")
+      } else {
+        n_selected <- length(selected)
+        selected_text <- paste(n_selected, "levels selected")
+      }
       tagList(
         tags$span(
           class = "filter-card-summary-value",
-          paste0(private$get_selected(), collapse = ", ")
+          selected_text
         ),
         tags$span(
           class = "filter-card-summary-controls",

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -476,7 +476,10 @@ DateFilterState <- R6::R6Class( # nolint
       min <- selected[1]
       max <- selected[2]
       tagList(
-        tags$span(paste0(min, " - ", max)),
+        tags$span(
+          class = "filter-card-summary-value",
+          paste0(min, " - ", max)
+        ),
         tags$span(
           class = "filter-card-summary-controls",
           if (isTRUE(private$get_keep_na()) && private$na_count > 0) {

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -478,7 +478,7 @@ DateFilterState <- R6::R6Class( # nolint
       tagList(
         tags$span(
           class = "filter-card-summary-value",
-          paste0(min, " - ", max)
+          shiny::HTML(min, "&ndash;", max)
         ),
         tags$span(
           class = "filter-card-summary-controls",

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -477,7 +477,10 @@ DateFilterState <- R6::R6Class( # nolint
       max <- selected[2]
       tagList(
         tags$span(paste0(min, " - ", max)),
-        if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL
+        tags$span(
+          class = "filter-card-summary-controls",
+          if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL
+        )
       )
     }
   )

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -479,7 +479,21 @@ DateFilterState <- R6::R6Class( # nolint
         tags$span(paste0(min, " - ", max)),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL
+          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("check")
+            )
+          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("xmark")
+            )
+          } else {
+            NULL
+          }
         )
       )
     }

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -599,7 +599,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
       tagList(
         tags$span(
           class = "filter-card-summary-value",
-          paste0(min, " - ", max)
+          shiny::HTML(min, "&ndash;", max)
         ),
         tags$span(
           class = "filter-card-summary-controls",

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -598,7 +598,10 @@ DatetimeFilterState <- R6::R6Class( # nolint
       max <- selected[2]
       tagList(
         tags$span(paste0(min, " - ", max)),
-        if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL
+        tags$span(
+          class = "filter-card-summary-controls",
+          if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL
+        )
       )
     }
   )

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -597,7 +597,10 @@ DatetimeFilterState <- R6::R6Class( # nolint
       min <- selected[1]
       max <- selected[2]
       tagList(
-        tags$span(paste0(min, " - ", max)),
+        tags$span(
+          class = "filter-card-summary-value",
+          paste0(min, " - ", max)
+        ),
         tags$span(
           class = "filter-card-summary-controls",
           if (isTRUE(private$get_keep_na()) && private$na_count > 0) {

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -600,7 +600,21 @@ DatetimeFilterState <- R6::R6Class( # nolint
         tags$span(paste0(min, " - ", max)),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL
+          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("check")
+            )
+          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("xmark")
+            )
+          } else {
+            NULL
+          }
         )
       )
     }

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -417,7 +417,21 @@ LogicalFilterState <- R6::R6Class( # nolint
         tags$span(private$get_selected(), class = "filter-card-summary-value"),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na())) tags$span("NA", class = "filter-card-summary-na") else NULL
+          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("check")
+            )
+          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("xmark")
+            )
+          } else {
+            NULL
+          }
         )
       )
     }

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -414,8 +414,11 @@ LogicalFilterState <- R6::R6Class( # nolint
     #  and if NA are included also
     content_summary = function(id) {
       tagList(
-        tags$span(private$get_selected()),
-        if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL
+        tags$span(private$get_selected(), class = "filter-card-summary-value"),
+        tags$span(
+          class = "filter-card-summary-controls",
+          if (isTRUE(private$get_keep_na())) tags$span("NA", class = "filter-card-summary-na") else NULL
+        )
       )
     }
   )

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -388,11 +388,11 @@ RangeFilterState <- R6::R6Class( # nolint
     #  if NA or Inf are included also
     # @return `shiny.tag` to include in the `ui_summary`
     content_summary = function() {
-      selected <- sprintf("%.4g", private$get_selected())
-      min <- selected[1]
-      max <- selected[2]
+      fmt_selected <- format_range_for_summary(private$get_selected())
+      min <- fmt_selected[1]
+      max <- fmt_selected[2]
       tagList(
-        tags$span(paste0(min, " - ", max), class = "filter-card-summary-value"),
+        tags$span(shiny::HTML(min, "&ndash;", max), class = "filter-card-summary-value"),
         tags$span(
           class = "filter-card-summary-controls",
           if (isTRUE(private$get_keep_na()) && private$na_count > 0) {

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -392,9 +392,12 @@ RangeFilterState <- R6::R6Class( # nolint
       min <- selected[1]
       max <- selected[2]
       tagList(
-        tags$span(paste0(min, " - ", max)),
-        if (isTRUE(private$get_keep_na())) tags$span("NA") else NULL,
-        if (isTRUE(private$get_keep_inf())) tags$span("Inf") else NULL
+        tags$span(paste0(min, " - ", max), class = "filter-card-summary-value"),
+        tags$span(
+          class = "filter-card-summary-controls",
+          if (isTRUE(private$get_keep_na())) tags$span("NA", class = "filter-card-summary-na") else NULL,
+          if (isTRUE(private$get_keep_inf())) tags$span("Inf", class = "filter-card-summary-inf") else NULL
+        )
       )
     },
 

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -395,8 +395,36 @@ RangeFilterState <- R6::R6Class( # nolint
         tags$span(paste0(min, " - ", max), class = "filter-card-summary-value"),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na())) tags$span("NA", class = "filter-card-summary-na") else NULL,
-          if (isTRUE(private$get_keep_inf())) tags$span("Inf", class = "filter-card-summary-inf") else NULL
+          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("check")
+            )
+          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
+            tags$span(
+              class = "filter-card-summary-na",
+              "NA",
+              shiny::icon("xmark")
+            )
+          } else {
+            NULL
+          },
+          if (isTRUE(private$get_keep_inf()) && private$inf_count > 0) {
+            tags$span(
+              class = "filter-card-summary-inf",
+              "Inf",
+              shiny::icon("check")
+            )
+          } else if (isFALSE(private$get_keep_inf()) && private$inf_count > 0) {
+            tags$span(
+              class = "filter-card-summary-inf",
+              "Inf",
+              shiny::icon("xmark")
+            )
+          } else {
+            NULL
+          }
         )
       )
     },

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -279,6 +279,13 @@ a.remove_all:hover {
   grid-area: summary;
 }
 
+.filter-card-summary-value {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .filter-card-summary-controls {
   margin-left: auto;
   display: flex;

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -285,6 +285,14 @@ a.remove_all:hover {
   gap: 1em;
 }
 
+.fa-check {
+  color: var(--bs-success, var(--success, #3c763d))
+}
+
+.fa-xmark {
+  color: var(--bs-danger, var(--danger, #a94442))
+}
+
 .filter-card-varlabel {
  color: var(--bs-gray-500, var(--gray, darkgray));
  margin-left: 0.5em;

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -276,8 +276,13 @@ a.remove_all:hover {
 .filter-card-summary {
   width: 100%;
   display: flex;
-  justify-content: space-between;
   grid-area: summary;
+}
+
+.filter-card-summary-controls {
+  margin-left: auto;
+  display: flex;
+  gap: 1em;
 }
 
 .filter-card-varlabel {

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -186,6 +186,9 @@ a.remove_all:hover {
   max-width: 100%;
 }
 
+.irs.irs--shiny.js-irs-0.irs-with-grid * {
+  font-size: 0.85em;
+}
 
 .filter_panel_dataname {
   font-weight: bold;
@@ -288,6 +291,7 @@ a.remove_all:hover {
 
 .filter-card-summary-controls {
   margin-left: auto;
+  padding-left: 1em;
   display: flex;
   gap: 1em;
 }
@@ -333,9 +337,22 @@ a.remove_all:hover {
   overflow: visible;
   text-align: left;
   white-space: nowrap;
+  font-size: 1em;
 }
 
 .progress-bar.state-count-bar-unfiltered {
   background-color: rgba(173, 216, 230, 0.439) !important;
 }
 
+.input-daterange > input {
+  font-size: 1em !important;
+}
+
+.input-group-prepend {
+ font-size: 1em !important;;
+}
+
+
+.filter_datelike_input  input {
+  font-size: 1em !important;
+}

--- a/tests/testthat/test-FilterState-utils.R
+++ b/tests/testthat/test-FilterState-utils.R
@@ -70,3 +70,54 @@ testthat::test_that("contain_interval returns 'x' if interval matches ticks", {
 testthat::test_that("contain_interval returns 'range' if 'x' is x is out of bounds", {
   testthat::expect_equal(contain_interval(c(0, 11), 1:10), c(1, 10))
 })
+
+testthat::test_that("n_sig_digits counts correctly", {
+  values <- as.character(c(
+    1.23,
+    exp(1),
+    pi,
+    45678,
+    0.0001245
+  ))
+
+  expected <- c(
+    3,
+    15,
+    15,
+    5,
+    4
+  )
+
+  testthat::expect_equal(n_sig_digits(values), expected)
+})
+
+testthat::test_that("formatting of range filter state for card summary", {
+  values <- c(
+    -10.000000235,
+    -4.5,
+    0.00,
+    0.00412,
+    pi,
+    12.01,
+    20.0,
+    14328948789,
+    -Inf,
+    Inf,
+    NA
+  )
+  expected <- c(
+    "-10",
+    "-4.5",
+    "0",
+    "0.00412",
+    "3.142E+00",
+    "12.01",
+    "20",
+    "1.433E+10",
+    "-Inf",
+    "Inf",
+    "NA"
+  )
+
+  testthat::expect_equal(format_range_for_summary(values), expected)
+})


### PR DESCRIPTION
Updates the summary row of the card header.

- Removes "Include" for NA/Inf
- Move NA/Inf contents further to the right of the card summary.
- NA/Inf displays "NA/Inf" with a check or X. Check if yes, X if no. If no NA or Inf are present in the column, nothing is displayed
- For value/selected portion of summary, the text is automatically truncated depending on screen width.
- For categorical variables, the selected/value display is as follows
  - if the total length of "level 1, level 2, level 3" is more than 40 characters, the text "N levels selected" is used.
  - otherwise, the selected levels are displayed
  - 40 characters is a magic number and is an approximation. I found it to be ~300px which is the total text limit. But different font sizes, capitalization vs. not, browser zoom, etc. will all affect the actual number of characters that = Xpx. So there's never going to be a "right" value for this
- For numeric and dates, an endash is used instead of "-" to separate the selected values
- For numeric variables, if there are > 4 significant digits the number is formatted in scientific notation with 4 significant digits. This is related to #251. If the current implementation is not exactly what we want, it should affect this PR. We can refine the method with #251.
- The font size of some peripherals of input elements were adjusted to match the font size in the card header.

Fixes #220
