### PR TITLE
Fix bug in ChoicesFilterState count labels

### DIFF
--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -177,7 +177,7 @@ ChoicesFilterState <- R6::R6Class( # nolint
         private$tzone <- Find(function(x) x != "", attr(as.POSIXlt(x), "tzone"))
       }
 
-      private$set_choices_counts(unname(table(x)))
+      private$set_choices_counts(unname(table(x_factor)))
 
       invisible(self)
     },


### PR DESCRIPTION
Fixes a bug in the count labels for `ChoicesFilterState`. Uses the x with any unused levels removed to set choices counts.

Fixes #260
