### PR TITLE
capture label and add after droplevels

### DIFF
--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -148,12 +148,16 @@ ChoicesFilterState <- R6::R6Class( # nolint
         combine = "or"
       )
 
+      label <- attr(x, "label")
+
       x_factor <- if (!is.factor(x)) {
         factor(as.character(x), levels = as.character(sort(unique(x))))
       } else {
         x
       }
+
       x_factor <- droplevels(x_factor)
+      attr(x_factor, "label") <- label
 
       args <- list(
         x = x_factor,


### PR DESCRIPTION
Fixes #271

### Summary
I captured the `label` attribute in FilterStateChoices before the factor or levels activity.
Then, before passing to parent initialization, added the `label` attribute back to the `x_factor` object.

This seems to fix the problem with the `label` in FilterStateChoices:
<img src="https://user-images.githubusercontent.com/8597300/236977313-a0184757-0ba0-4e2f-bdf9-1b940bc50a44.png"  height="50%" width="50%" />
