### PR TITLE
Prevent disable/remove buttons from overflowing card

### DIFF
--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -271,7 +271,7 @@ a.remove_all:hover {
 
 .filter-card-controls {
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   gap: 1em;
   grid-area: controls;
 }


### PR DESCRIPTION
Keeps the disable switch and remove icon inside the card if the browser width narrows.

Fixes #236
