### PR TITLE
280 locked filter

### DIFF
--- a/R/FilterState-utils.R
+++ b/R/FilterState-utils.R
@@ -23,12 +23,14 @@
 #'   flag specifying whether to keep missing values
 #' @param keep_inf (`logical(1)`, `NULL`)\cr
 #'   flag specifying whether to keep infinite values
-#' @param fixed (`logical(1)`)\cr
-#'   flag specifying whether the `FilterState` is initiated fixed
 #' @param disabled (`logical(1)`)\cr
 #'   flag specifying whether the `FilterState` is initiated disabled
+#' @param fixed (`logical(1)`)\cr
+#'   flag specifying whether the `FilterState` is initiated fixed
+#' @param locked (`logical(1)`)\cr
+#'   flag specifying whether the `FilterState` is initiated locked
 #' @param extract_type (`character(0)`, `character(1)`)\cr
-#' whether condition calls should be prefixed by dataname. Possible values:
+#'   specifying whether condition calls should be prefixed by `dataname`. Possible values:
 #' \itemize{
 #' \item{`character(0)` (default)}{ `varname` in the condition call will not be prefixed}
 #' \item{`"list"`}{ `varname` in the condition call will be returned as `<dataname>$<varname>`}
@@ -73,8 +75,9 @@ init_filter_state <- function(x,
                               selected = NULL,
                               keep_na = NULL,
                               keep_inf = NULL,
-                              fixed = FALSE,
                               disabled = FALSE,
+                              fixed = FALSE,
+                              locked = FALSE,
                               extract_type = character(0),
                               ...) {
   checkmate::assert_class(x_reactive, "reactive")
@@ -83,8 +86,9 @@ init_filter_state <- function(x,
   checkmate::assert_flag(multiple, null.ok = TRUE)
   checkmate::assert_flag(keep_na, null.ok = TRUE)
   checkmate::assert_flag(keep_inf, null.ok = TRUE)
-  checkmate::assert_flag(fixed)
   checkmate::assert_flag(disabled)
+  checkmate::assert_flag(fixed)
+  checkmate::assert_flag(locked)
   checkmate::assert_character(extract_type, max.len = 1, any.missing = FALSE)
   if (length(extract_type) == 1) {
     checkmate::assert_choice(extract_type, choices = c("list", "matrix"))
@@ -101,8 +105,9 @@ init_filter_state <- function(x,
       selected = selected,
       keep_na = keep_na,
       keep_inf = keep_inf,
-      fixed = fixed,
       disabled = disabled,
+      fixed = fixed,
+      locked = locked,
       extract_type = extract_type
     )
     args <- append(args, list(...))
@@ -124,8 +129,9 @@ init_filter_state.default <- function(x,
                                       selected = NULL,
                                       keep_na = NULL,
                                       keep_inf = NULL,
-                                      fixed = FALSE,
                                       disabled = FALSE,
+                                      fixed = FALSE,
+                                      locked = FALSE,
                                       extract_type = character(0),
                                       ...) {
   args <- list(
@@ -138,8 +144,9 @@ init_filter_state.default <- function(x,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
-    fixed = fixed,
     disabled = disabled,
+    fixed = fixed,
+    locked = locked,
     extract_type = extract_type
   )
   args <- append(args, list(...))
@@ -158,8 +165,9 @@ init_filter_state.logical <- function(x,
                                       selected = NULL,
                                       keep_na = NULL,
                                       keep_inf = NULL,
-                                      fixed = FALSE,
                                       disabled = FALSE,
+                                      fixed = FALSE,
+                                      locked = FALSE,
                                       extract_type = character(0),
                                       ...) {
   args <- list(
@@ -172,8 +180,9 @@ init_filter_state.logical <- function(x,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
-    fixed = fixed,
     disabled = disabled,
+    fixed = fixed,
+    locked = locked,
     extract_type = extract_type
   )
   args <- append(args, list(...))
@@ -192,8 +201,9 @@ init_filter_state.numeric <- function(x,
                                       selected = NULL,
                                       keep_na = NULL,
                                       keep_inf = NULL,
-                                      fixed = FALSE,
                                       disabled = FALSE,
+                                      fixed = FALSE,
+                                      locked = FALSE,
                                       extract_type = character(0),
                                       ...) {
   args <- list(
@@ -206,8 +216,9 @@ init_filter_state.numeric <- function(x,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
-    fixed = fixed,
     disabled = disabled,
+    fixed = fixed,
+    locked = locked,
     extract_type = extract_type
   )
   args <- append(args, list(...))
@@ -230,8 +241,9 @@ init_filter_state.factor <- function(x,
                                      selected = NULL,
                                      keep_na = NULL,
                                      keep_inf = NULL,
-                                     fixed = FALSE,
                                      disabled = FALSE,
+                                     fixed = FALSE,
+                                     locked = FALSE,
                                      extract_type = character(0),
                                      ...) {
   args <- list(
@@ -244,8 +256,9 @@ init_filter_state.factor <- function(x,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
-    fixed = fixed,
     disabled = disabled,
+    fixed = fixed,
+    locked = locked,
     extract_type = extract_type
   )
   args <- append(args, list(...))
@@ -264,8 +277,9 @@ init_filter_state.character <- function(x,
                                         selected = NULL,
                                         keep_na = NULL,
                                         keep_inf = NULL,
-                                        fixed = FALSE,
                                         disabled = FALSE,
+                                        fixed = FALSE,
+                                        locked = FALSE,
                                         extract_type = character(0),
                                         ...) {
   args <- list(
@@ -278,8 +292,9 @@ init_filter_state.character <- function(x,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
-    fixed = fixed,
     disabled = disabled,
+    fixed = fixed,
+    locked = locked,
     extract_type = extract_type
   )
   args <- append(args, list(...))
@@ -298,8 +313,9 @@ init_filter_state.Date <- function(x,
                                    selected = NULL,
                                    keep_na = NULL,
                                    keep_inf = NULL,
-                                   fixed = FALSE,
                                    disabled = FALSE,
+                                   fixed = FALSE,
+                                   locked = FALSE,
                                    extract_type = character(0),
                                    ...) {
   args <- list(
@@ -312,8 +328,9 @@ init_filter_state.Date <- function(x,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
-    fixed = fixed,
     disabled = disabled,
+    fixed = fixed,
+    locked = locked,
     extract_type = extract_type
   )
   args <- append(args, list(...))
@@ -336,8 +353,9 @@ init_filter_state.POSIXct <- function(x,
                                       selected = NULL,
                                       keep_na = NULL,
                                       keep_inf = NULL,
-                                      fixed = FALSE,
                                       disabled = FALSE,
+                                      fixed = FALSE,
+                                      locked = FALSE,
                                       extract_type = character(0),
                                       ...) {
   args <- list(
@@ -350,8 +368,9 @@ init_filter_state.POSIXct <- function(x,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
-    fixed = fixed,
     disabled = disabled,
+    fixed = fixed,
+    locked = locked,
     extract_type = extract_type
   )
   args <- append(args, list(...))
@@ -374,8 +393,9 @@ init_filter_state.POSIXlt <- function(x,
                                       selected = NULL,
                                       keep_na = NULL,
                                       keep_inf = NULL,
-                                      fixed = FALSE,
                                       disabled = FALSE,
+                                      fixed = FALSE,
+                                      locked = FALSE,
                                       extract_type = character(0),
                                       ...) {
   args <- list(
@@ -388,8 +408,9 @@ init_filter_state.POSIXlt <- function(x,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
-    fixed = fixed,
     disabled = disabled,
+    fixed = fixed,
+    locked = locked,
     extract_type = extract_type
   )
   args <- append(args, list(...))
@@ -421,6 +442,8 @@ init_filter_state.POSIXlt <- function(x,
 #'   can be written without prefixing `var1 == "x" & var2 > 0`.
 #' @param disabled (`logical(1)`)\cr
 #'   flag specifying whether the `FilterState` is initiated disabled
+#' @param locked (`logical(1)`)\cr
+#'   flag specifying whether the `FilterState` is initiated locked
 #' @param ... additional arguments to be saved as a list in `private$extras` field
 #'
 #' @return `FilterStateExpr` object

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -525,7 +525,7 @@ ChoicesFilterState <- R6::R6Class( # nolint
                 # for length of input$selection other then 1 previous input is restored
                 showNotification(
                   "This filter exclusively supports single selection. Any additional choices made will be disregarded."
-                  )
+                )
                 teal.widgets::updateOptionalSelectInput(
                   session, "selection",
                   selected = private$get_selected()

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -521,8 +521,11 @@ ChoicesFilterState <- R6::R6Class( # nolint
 
               selection <- if (is.null(input$selection) && private$multiple) {
                 character(0)
-              } else if (isTRUE(length(input$selection) != 1) && !private$multiple) { # for length of input$selection other then 1 previous input is restored
-                showNotification("This filter exclusively supports single selection. Any additional choices made will be disregarded.")
+              } else if (isTRUE(length(input$selection) != 1) && !private$multiple) {
+                # for length of input$selection other then 1 previous input is restored
+                showNotification(
+                  "This filter exclusively supports single selection. Any additional choices made will be disregarded."
+                  )
                 teal.widgets::updateOptionalSelectInput(
                   session, "selection",
                   selected = private$get_selected()

--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -32,6 +32,8 @@ FilterStateExpr <- R6::R6Class( # nolint
     #'   can be written without prefixing `var1 == "x" & var2 > 0`.
     #' @param disabled (`logical(1)`)\cr
     #'   flag specifying whether the `FilterState` is initiated disabled
+    #' @param locked (`logical(1)`) \cr
+    #'   flag specifying whether the `FilterState` is initiated locked
     #' @param ... additional arguments to be saved as a list in `private$extras` field
     #' @examples
     #' filter_state <- teal.slice:::FilterStateExpr$new(
@@ -78,19 +80,22 @@ FilterStateExpr <- R6::R6Class( # nolint
     #' }
     #'
     #' @return `FilterStateExpr`
-    initialize = function(dataname, id, title, expr, disabled = FALSE, ...) {
+    initialize = function(dataname, id, title, expr, disabled = FALSE, locked = FALSE, ...) {
       checkmate::assert_string(dataname)
       checkmate::assert_string(id)
       checkmate::assert_string(title)
       checkmate::assert_flag(disabled)
+      checkmate::assert_flag(locked)
       checkmate::assert_string(expr)
 
+      private$dataname <- dataname
       private$id <- id
       private$title <- title
-      private$dataname <- dataname
       private$expr <- expr
       private$disabled <- reactiveVal(disabled)
+      private$locked <- locked
       private$extras <- list(...)
+
       invisible(self)
     },
 
@@ -125,11 +130,12 @@ FilterStateExpr <- R6::R6Class( # nolint
     get_state = function() {
       states <- append(
         list(
+          dataname = private$dataname,
           id = private$id,
           title = private$title,
-          dataname = private$dataname,
           expr = private$expr,
-          disable = private$disabled()
+          disabled = private$disabled(),
+          locked = private$locked
         ),
         private$extras
       )
@@ -145,8 +151,12 @@ FilterStateExpr <- R6::R6Class( # nolint
     #'
     set_state = function(state) {
       checkmate::assert_class(state, "teal_slice_expr")
-      if (isTRUE(state$disabled) && isFALSE(private$is_disabled())) private$disabled(TRUE)
-      if (isFALSE(state$disabled) && isTRUE(private$is_disabled())) private$disabled(FALSE)
+      if (isTRUE(private$locked)) {
+        logger::log_warn("attempt to disable a locked filter aborted: { private$dataname } { private$varname }")
+      } else {
+        if (isTRUE(state$disabled) && isFALSE(private$is_disabled())) private$disabled(TRUE)
+        if (isFALSE(state$disabled) && isTRUE(private$is_disabled())) private$disabled(FALSE)
+      }
       invisible(NULL)
     },
 
@@ -166,6 +176,18 @@ FilterStateExpr <- R6::R6Class( # nolint
       }
       str2lang(private$expr)
     },
+
+    #' @description
+    #' Destroy observers stored in `private$observers`.
+    #'
+    #' @return NULL invisibly
+    #'
+    destroy_observers = function() {
+      lapply(private$observers, function(x) x$destroy())
+      invisible(NULL)
+    },
+
+    # public shiny modules ----
 
     #' @description
     #' Shiny module server.
@@ -254,25 +276,22 @@ FilterStateExpr <- R6::R6Class( # nolint
           )
         )
       )
-    },
-    #' @description
-    #' Destroy observers stored in `private$observers`.
-    #'
-    #' @return NULL invisibly
-    #'
-    destroy_observers = function() {
-      lapply(private$observers, function(x) x$destroy())
-      return(invisible(NULL))
     }
   ),
+
+  # private members ----
+
   private = list(
     dataname = character(0),
-    disabled = NULL,
-    expr = NULL,
-    extras = list(),
     id = character(0),
-    observers = list(),
+    expr = NULL,
     title = character(0),
+    disabled = NULL,
+    locked = logical(0),
+    extras = list(),
+    observers = list(),
+
+    # private methods ----
 
     # Check whether this filter is disabled
     # @return `logical(1)`
@@ -283,6 +302,11 @@ FilterStateExpr <- R6::R6Class( # nolint
         shiny::isolate(isTRUE(private$disabled()))
       }
     },
+    content_summary = function() {
+      private$expr
+    },
+
+    # shiny modules ----
 
     # @description
     # Server module to display filter summary
@@ -309,9 +333,6 @@ FilterStateExpr <- R6::R6Class( # nolint
           })
         }
       )
-    },
-    content_summary = function() {
-      private$expr
     }
   )
 )

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -763,14 +763,31 @@ FilterStates <- R6::R6Class( # nolint
     # @return invisible NULL
     #
     state_list_empty = function() {
-      logger::log_trace("{ class(self)[1] }$state_list_empty removing all filters for dataname: { private$dataname }")
+      logger::log_trace(
+        "{ class(self)[1] }$state_list_empty removing all non-locked filters for dataname: { private$dataname }"
+      )
 
       state_list <- shiny::isolate(private$state_list())
       for (state_id in names(state_list)) {
-        private$state_list_remove(state_id)
+        is_locked <- shiny::isolate(private$state_list()[[state_id]]$get_state()$locked)
+        if (is_locked) {
+          logger::log_trace(
+            paste0(
+              "{ class(self)[1] }$state_list_empty aborted removing (locked) filter, ",
+              "dataname: { private$dataname }; state_id: { state_id }"
+            )
+          )
+        } else {
+          logger::log_trace(
+            "{ class(self)[1] }$state_list_empty removed filter, dataname: { private$dataname }; state_id: { state_id }"
+          )
+          private$state_list_remove(state_id)
+        }
       }
 
-      logger::log_trace("{ class(self)[1] }$state_list_empty removed all filters for dataname: { private$dataname }")
+      logger::log_trace(
+        "{ class(self)[1] }$state_list_empty removed all non-locked filters for dataname: { private$dataname }"
+      )
       invisible(NULL)
     },
 

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -89,12 +89,12 @@ FilteredDataset <- R6::R6Class( # nolint
     #' Removes all active filter items applied to this dataset
     #' @return NULL
     clear_filter_states = function() {
-      logger::log_trace("Removing all filters from FilteredDataset: { deparse1(self$get_dataname()) }")
+      logger::log_trace("Removing all non-locked filters from FilteredDataset: { deparse1(self$get_dataname()) }")
       lapply(
         private$get_filter_states(),
         function(filter_states) filter_states$clear_filter_states()
       )
-      logger::log_trace("Removed all filters from FilteredDataset: { deparse1(self$get_dataname()) }")
+      logger::log_trace("Removed all non-locked filters from FilteredDataset: { deparse1(self$get_dataname()) }")
       NULL
     },
 
@@ -329,9 +329,9 @@ FilteredDataset <- R6::R6Class( # nolint
           })
 
           observeEvent(input$remove_filters, {
-            logger::log_trace("FilteredDataset$srv_active@1 removing filters, dataname: { dataname }")
+            logger::log_trace("FilteredDataset$srv_active@1 removing all non-locked filters, dataname: { dataname }")
             self$clear_filter_states()
-            logger::log_trace("FilteredDataset$srv_active@1 removed filters, dataname: { dataname }")
+            logger::log_trace("FilteredDataset$srv_active@1 removed all non-locked filters, dataname: { dataname }")
           })
 
           logger::log_trace("FilteredDataset$initialized, dataname: { dataname }")

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -6,25 +6,29 @@
 #' A single filter state can be fully described by a `teal_slice` object and such
 #' objects will be used to create, modify, and delete a filter state.
 #'
-#' A `teal_slice` contains a number of common fields (all named arguments of `filter_var`)
-#' but only `dataname` and `varname` are mandatory, while the others have default values.
-#' Setting any of the other values to NULL means that these parameters will not be modified
+#' A `teal_slice` contains a number of common fields (all named arguments of `filter_var`),
+#' some of which are mandatory, but only `dataname` and `varname` must be specified,
+#' while the others have default values.
+#' Setting any of the other values to NULL means that those properties will not be modified
 #' (when setting an existing state) or that they will be determined by data (when creating new a new one).
 #' Each of the common fields corresponds to one private field in `FilterState`
 #' where it is stored and from where it is retrieved when calling `FiterState$get_state`.
 #'
 #' A `teal_slice` can also contain any number of additional fields, passed to `...`
 #' as `name:value` pairs. These are collated into a list and stored in the
-#' `private$extras` field.
+#' `private$extras` field in `FilterState`.
 #'
 #' All `teal_slice` fields can be passed as arguments to `FilterState` constructors.
 #' A `teal_slice` can be passed to `FilterState$set_state`, which will modify the state.
 #' However, once a `FilterState` is created, only the **mutable** features can be set with a `teal_slice`:
 #' `selected`, `keep_na`, `keep_inf`, and `disabled`.
 #'
-#' Special consideration is given to the `fixed` field. This is always a logical flag that defaults to FALSE.
+#' Special consideration is given to two fields: `fixed` and `locked`.
+#' These are always immutable logical flags that default to FALSE.
 #' In a `FilterState` instantiated with `fixed = TRUE` the features `selected`, `keep_na`, `keep_inf`
-#' cannot be changed but the`disabled` can.
+#' cannot be changed but the `disabled` feature can.
+#' A `FilterState` instantiated with `locked = TRUE` cannot be disabled or removed.
+#' Any combination of `fixed` and `locked` is permitted.
 #'
 #' `filter_var` creates a `teal_slice` object, which specifies a filter for a single variable,
 #' passed to and resolved by `FilterState` objects.
@@ -33,6 +37,11 @@
 #' as well as `filter_panel_api` wrapper functions.
 #' `teal_slices` also specifies which variables cannot be filtered
 #' and how observations are tallied, which is resolved by `FilterStates`.
+#'
+#' `include_varnames` and `exclude_varnames` in attributes in `teal_slices`
+#' determine which variables can have filters assigned.
+#' The former enumerates allowed variables, the latter enumerates forbidden values.
+#' Since these can be mutually exclusive in some cases, they cannot both be set in one `teal_slices` object.
 #'
 #' @section Filters in `SumarizedExperiment` and `MultiAssayExperiment` objects:
 #'
@@ -48,6 +57,7 @@
 #' that names either an experiment (as listed in `experimentList(<MAE>)`) or "subjects"
 #' if it refers to the `MultiAssaysExperiment` `colData`. They must **also** specify `arg` as "subset" or "select"
 #' for experiments and as "y" for `colData`.
+#'
 #' @param dataname `character(1)` name of data set
 #' @param varname `character(1)` name of variable
 #' @param choices optional vector specifying allowed choices;
@@ -59,16 +69,12 @@
 #'  type and size depends on variable type
 #' @param keep_na `logical(1)` or `NULL` optional logical flag specifying whether to keep missing values
 #' @param keep_inf `logical(1)` or `NULL` optional logical flag specifying whether to keep infinite values
-#' @param fixed `logical(1)` logical flag specifying whether to fix this filter state (i.e. forbid setting state)
-#' @param disabled `logical(1)`logical flag specifying whether to disable this filter state
-#' @param include_varnames `named list` of `character` vectors where list names match names of data sets
-#'  and vector elements match variable names in respective data sets;
-#'  specifies which variables are not allowed to be filtered.
-#'  Both `include_varnames` and `exclude_varnames` can't be specified for the same dataset in the same call.
-#' @param exclude_varnames `named list` of `character` vectors where list names match names of data sets
-#'  and vector elements match variable names in respective data sets;
-#'  specifies which variables are not allowed to be filtered.
-#'  Both `include_varnames` and `exclude_varnames` can't be specified for the same dataset in the same call.
+#' @param disabled `logical(1)` logical flag specifying whether to disable this filter state
+#' @param fixed `logical(1)` logical flag specifying whether to fix this filter state (forbid setting state)
+#' @param locked `logical(1)` logical flag specifying whether to lock this filter state (forbid disabling and removing)
+#' @param include_varnames,exclude_varnames `named list`s of `character` vectors where list names
+#'  match names of data sets and vector elements match variable names in respective data sets;
+#'  specify which variables are allowed to be filtered; see `Details`
 #' @param count_type `character(1)` string specifying how observations are tallied by these filter states.
 #'  Possible options:
 #'  - `"all"` to have counts of single `FilterState` to show number of observation in filtered
@@ -79,10 +85,11 @@
 #' @param title (`reactive`)\cr
 #'   title of the filter (used by `filter_expr`)
 #' @param expr (`language`)\cr
-#'   logical expression written in executable way. By "executable" means
-#'   that `subset` call should be able to evaluate this without failure. For
+#'   logical expression written in executable way, see `Details`
+#'   where "executable" means
+#'   that a `subset` call should be able to evaluate this without failure. For
 #'   example `MultiAssayExperiment::subsetByColData` requires variable names prefixed
-#'   by dataname (e.g. `data$var1 == "x" & data$var2 > 0`). For `data.frame` call
+#'   by `dataname` (e.g. `data$var1 == "x" & data$var2 > 0`). For `data.frame` call
 #'   can be written without prefixing `var1 == "x" & var2 > 0`.
 #' @param disabled (`logical(1)`)\cr
 #'   flag specifying whether the `FilterState` is initiated disabled
@@ -90,12 +97,13 @@
 #' @param show_all `logical(1)` specifying whether NULL elements should also be printed
 #' @param tss `teal_slices`
 #' @param field `character(1)` name of `teal_slice` element
-#' @param ... for `filter_var` any number of additional fields given as `name:value` pairs\cr
+#' @param ... for `filter_var` and `filter_expr` any number of additional fields given as `name:value` pairs\cr
 #'            for `filter_settings` any number of `teal_slice` objects\cr
 #'            for other functions arguments passed to other methods
 #'
 #' @return
 #' `filter_var` returns object of class `teal_slice`, which is a named list.
+#' `filter_expr` returns object of class `teal_slice_expr`, which inherits from `teal_slice`.
 #' `filter_settings` returns object of class `teal_slices`, which is an unnamed list of `teal_slice` objects.
 #'
 #' @examples
@@ -133,8 +141,9 @@ filter_var <- function(dataname,
                        selected = NULL,
                        keep_na = NULL,
                        keep_inf = NULL,
-                       fixed = FALSE,
                        disabled = FALSE,
+                       fixed = FALSE,
+                       locked = FALSE,
                        ...) {
   checkmate::assert_string(dataname)
   checkmate::assert_string(varname)
@@ -143,8 +152,9 @@ filter_var <- function(dataname,
   checkmate::assert_multi_class(selected, .filterable_class, null.ok = TRUE)
   checkmate::assert_flag(keep_na, null.ok = TRUE)
   checkmate::assert_flag(keep_inf, null.ok = TRUE)
-  checkmate::assert_flag(fixed)
   checkmate::assert_flag(disabled)
+  checkmate::assert_flag(fixed)
+  checkmate::assert_flag(locked)
 
   ans <- list(
     dataname = dataname,
@@ -154,8 +164,9 @@ filter_var <- function(dataname,
     selected = selected,
     keep_na = keep_na,
     keep_inf = keep_inf,
+    disabled = disabled,
     fixed = fixed,
-    disabled = disabled
+    locked = locked
   )
   ans <- append(ans, list(...))
 
@@ -172,7 +183,7 @@ filter_var <- function(dataname,
 #'   title = "Female adults",
 #'   expr = "SEX == 'F' & AGE >= 18"
 #' )
-filter_expr <- function(dataname, id, title, expr, disabled = FALSE, ...) {
+filter_expr <- function(dataname, id, title, expr, disabled = FALSE, locked = FALSE, ...) {
   checkmate::assert_string(dataname)
   checkmate::assert_string(id)
   checkmate::assert_string(title)
@@ -183,7 +194,8 @@ filter_expr <- function(dataname, id, title, expr, disabled = FALSE, ...) {
     title = title,
     dataname = dataname,
     expr = expr,
-    disabled = disabled
+    disabled = disabled,
+    locked = locked
   )
   ans <- append(ans, list(...))
   class(ans) <- c("teal_slice_expr", "teal_slice", class(ans))

--- a/man/FilterState.Rd
+++ b/man/FilterState.Rd
@@ -76,8 +76,9 @@ Initialize a \code{FilterState} object
   multiple = NULL,
   keep_na = NULL,
   keep_inf = NULL,
-  fixed = FALSE,
   disabled = FALSE,
+  fixed = FALSE,
+  locked = FALSE,
   extract_type = character(0),
   ...
 )}\if{html}{\out{</div>}}
@@ -112,14 +113,17 @@ flag specifying whether to keep missing values}
 \item{\code{keep_inf}}{(\code{logical(1)}, \code{NULL})\cr
 flag specifying whether to keep infinite values}
 
-\item{\code{fixed}}{(\code{logical(1)})\cr
-flag specifying whether the \code{FilterState} is initiated fixed}
-
 \item{\code{disabled}}{(\code{logical(1)})\cr
 flag specifying whether the \code{FilterState} is initiated disabled}
 
+\item{\code{fixed}}{(\code{logical(1)})\cr
+flag specifying whether the \code{FilterState} is initiated fixed}
+
+\item{\code{locked}}{(\code{logical(1)}) \cr
+flag specifying whether to lock this filter state (forbid disabling and removing)}
+
 \item{\code{extract_type}}{(\code{character(0)}, \code{character(1)})\cr
-whether condition calls should be prefixed by dataname. Possible values:
+specifying whether condition calls should be prefixed by \code{dataname}. Possible values:
 \itemize{
 \item{\code{character(0)} (default)}{ \code{varname} in the condition call will not be prefixed}
 \item{\code{"list"}}{ \code{varname} in the condition call will be returned as \verb{<dataname>$<varname>}}
@@ -176,6 +180,11 @@ Prints this \code{FilterState} object.
 \if{latex}{\out{\hypertarget{method-FilterState-set_state}{}}}
 \subsection{Method \code{set_state()}}{
 Sets filtering state.
+\itemize{
+\item \code{fixed} state is prevented from changing state
+\item \code{disabled} state is prevented from changing state, but may be enabled and changed in one operation
+\item \code{locked} state is prevented from changing \code{disabled} status
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilterState$set_state(state)}\if{html}{\out{</div>}}
 }

--- a/man/FilterStateExpr.Rd
+++ b/man/FilterStateExpr.Rd
@@ -70,9 +70,9 @@ if (interactive()) {
 \item \href{#method-FilterStateExpr-get_state}{\code{FilterStateExpr$get_state()}}
 \item \href{#method-FilterStateExpr-set_state}{\code{FilterStateExpr$set_state()}}
 \item \href{#method-FilterStateExpr-get_call}{\code{FilterStateExpr$get_call()}}
+\item \href{#method-FilterStateExpr-destroy_observers}{\code{FilterStateExpr$destroy_observers()}}
 \item \href{#method-FilterStateExpr-server}{\code{FilterStateExpr$server()}}
 \item \href{#method-FilterStateExpr-ui}{\code{FilterStateExpr$ui()}}
-\item \href{#method-FilterStateExpr-destroy_observers}{\code{FilterStateExpr$destroy_observers()}}
 \item \href{#method-FilterStateExpr-clone}{\code{FilterStateExpr$clone()}}
 }
 }
@@ -82,7 +82,15 @@ if (interactive()) {
 \subsection{Method \code{new()}}{
 Initialize a \code{FilterStateExpr} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilterStateExpr$new(dataname, id, title, expr, disabled = FALSE, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilterStateExpr$new(
+  dataname,
+  id,
+  title,
+  expr,
+  disabled = FALSE,
+  locked = FALSE,
+  ...
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -106,6 +114,9 @@ can be written without prefixing \code{var1 == "x" & var2 > 0}.}
 
 \item{\code{disabled}}{(\code{logical(1)})\cr
 flag specifying whether the \code{FilterState} is initiated disabled}
+
+\item{\code{locked}}{(\code{logical(1)}) \cr
+flag specifying whether the \code{FilterState} is initiated locked}
 
 \item{\code{...}}{additional arguments to be saved as a list in \code{private$extras} field}
 }
@@ -261,6 +272,19 @@ and must be executed in reactive or isolated context.}
 }
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-FilterStateExpr-destroy_observers"></a>}}
+\if{latex}{\out{\hypertarget{method-FilterStateExpr-destroy_observers}{}}}
+\subsection{Method \code{destroy_observers()}}{
+Destroy observers stored in \code{private$observers}.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{FilterStateExpr$destroy_observers()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+NULL invisibly
+}
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FilterStateExpr-server"></a>}}
 \if{latex}{\out{\hypertarget{method-FilterStateExpr-server}{}}}
 \subsection{Method \code{server()}}{
@@ -301,19 +325,6 @@ the UI for this class contains simple message stating that it is not supported}
 \item{\code{parent_id}}{(\code{character(1)}) id of the FilterStates card container}
 }
 \if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-FilterStateExpr-destroy_observers"></a>}}
-\if{latex}{\out{\hypertarget{method-FilterStateExpr-destroy_observers}{}}}
-\subsection{Method \code{destroy_observers()}}{
-Destroy observers stored in \code{private$observers}.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilterStateExpr$destroy_observers()}\if{html}{\out{</div>}}
-}
-
-\subsection{Returns}{
-NULL invisibly
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/init_filter_state.Rd
+++ b/man/init_filter_state.Rd
@@ -14,8 +14,9 @@ init_filter_state(
   selected = NULL,
   keep_na = NULL,
   keep_inf = NULL,
-  fixed = FALSE,
   disabled = FALSE,
+  fixed = FALSE,
+  locked = FALSE,
   extract_type = character(0),
   ...
 )
@@ -52,14 +53,17 @@ flag specifying whether to keep missing values}
 \item{keep_inf}{(\code{logical(1)}, \code{NULL})\cr
 flag specifying whether to keep infinite values}
 
-\item{fixed}{(\code{logical(1)})\cr
-flag specifying whether the \code{FilterState} is initiated fixed}
-
 \item{disabled}{(\code{logical(1)})\cr
 flag specifying whether the \code{FilterState} is initiated disabled}
 
+\item{fixed}{(\code{logical(1)})\cr
+flag specifying whether the \code{FilterState} is initiated fixed}
+
+\item{locked}{(\code{logical(1)})\cr
+flag specifying whether the \code{FilterState} is initiated locked}
+
 \item{extract_type}{(\code{character(0)}, \code{character(1)})\cr
-whether condition calls should be prefixed by dataname. Possible values:
+specifying whether condition calls should be prefixed by \code{dataname}. Possible values:
 \itemize{
 \item{\code{character(0)} (default)}{ \code{varname} in the condition call will not be prefixed}
 \item{\code{"list"}}{ \code{varname} in the condition call will be returned as \verb{<dataname>$<varname>}}

--- a/man/init_filter_state_expr.Rd
+++ b/man/init_filter_state_expr.Rd
@@ -27,6 +27,9 @@ can be written without prefixing \code{var1 == "x" & var2 > 0}.}
 flag specifying whether the \code{FilterState} is initiated disabled}
 
 \item{...}{additional arguments to be saved as a list in \code{private$extras} field}
+
+\item{locked}{(\code{logical(1)})\cr
+flag specifying whether the \code{FilterState} is initiated locked}
 }
 \value{
 \code{FilterStateExpr} object

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -28,12 +28,13 @@ filter_var(
   selected = NULL,
   keep_na = NULL,
   keep_inf = NULL,
-  fixed = FALSE,
   disabled = FALSE,
+  fixed = FALSE,
+  locked = FALSE,
   ...
 )
 
-filter_expr(dataname, id, title, expr, disabled = FALSE, ...)
+filter_expr(dataname, id, title, expr, disabled = FALSE, locked = FALSE, ...)
 
 filter_settings(
   ...,
@@ -87,12 +88,14 @@ type and size depends on variable type}
 
 \item{keep_inf}{\code{logical(1)} or \code{NULL} optional logical flag specifying whether to keep infinite values}
 
-\item{fixed}{\code{logical(1)} logical flag specifying whether to fix this filter state (i.e. forbid setting state)}
-
 \item{disabled}{(\code{logical(1)})\cr
 flag specifying whether the \code{FilterState} is initiated disabled}
 
-\item{...}{for \code{filter_var} any number of additional fields given as \code{name:value} pairs\cr
+\item{fixed}{\code{logical(1)} logical flag specifying whether to fix this filter state (forbid setting state)}
+
+\item{locked}{\code{logical(1)} logical flag specifying whether to lock this filter state (forbid disabling and removing)}
+
+\item{...}{for \code{filter_var} and \code{filter_expr} any number of additional fields given as \code{name:value} pairs\cr
 for \code{filter_settings} any number of \code{teal_slice} objects\cr
 for other functions arguments passed to other methods}
 
@@ -103,21 +106,16 @@ identifier of the filter}
 title of the filter (used by \code{filter_expr})}
 
 \item{expr}{(\code{language})\cr
-logical expression written in executable way. By "executable" means
-that \code{subset} call should be able to evaluate this without failure. For
+logical expression written in executable way, see \code{Details}
+where "executable" means
+that a \code{subset} call should be able to evaluate this without failure. For
 example \code{MultiAssayExperiment::subsetByColData} requires variable names prefixed
-by dataname (e.g. \code{data$var1 == "x" & data$var2 > 0}). For \code{data.frame} call
+by \code{dataname} (e.g. \code{data$var1 == "x" & data$var2 > 0}). For \code{data.frame} call
 can be written without prefixing \code{var1 == "x" & var2 > 0}.}
 
-\item{exclude_varnames}{\verb{named list} of \code{character} vectors where list names match names of data sets
-and vector elements match variable names in respective data sets;
-specifies which variables are not allowed to be filtered.
-Both \code{include_varnames} and \code{exclude_varnames} can't be specified for the same dataset in the same call.}
-
-\item{include_varnames}{\verb{named list} of \code{character} vectors where list names match names of data sets
-and vector elements match variable names in respective data sets;
-specifies which variables are not allowed to be filtered.
-Both \code{include_varnames} and \code{exclude_varnames} can't be specified for the same dataset in the same call.}
+\item{include_varnames, exclude_varnames}{\verb{named list}s of \code{character} vectors where list names
+match names of data sets and vector elements match variable names in respective data sets;
+specify which variables are allowed to be filtered; see \code{Details}}
 
 \item{count_type}{\code{character(1)} string specifying how observations are tallied by these filter states.
 Possible options:
@@ -135,6 +133,7 @@ and unfiltered dataset.
 }
 \value{
 \code{filter_var} returns object of class \code{teal_slice}, which is a named list.
+\code{filter_expr} returns object of class \code{teal_slice_expr}, which inherits from \code{teal_slice}.
 \code{filter_settings} returns object of class \code{teal_slices}, which is an unnamed list of \code{teal_slice} objects.
 }
 \description{
@@ -145,25 +144,29 @@ These functions create and manage filter state specifications.
 A single filter state can be fully described by a \code{teal_slice} object and such
 objects will be used to create, modify, and delete a filter state.
 
-A \code{teal_slice} contains a number of common fields (all named arguments of \code{filter_var})
-but only \code{dataname} and \code{varname} are mandatory, while the others have default values.
-Setting any of the other values to NULL means that these parameters will not be modified
+A \code{teal_slice} contains a number of common fields (all named arguments of \code{filter_var}),
+some of which are mandatory, but only \code{dataname} and \code{varname} must be specified,
+while the others have default values.
+Setting any of the other values to NULL means that those properties will not be modified
 (when setting an existing state) or that they will be determined by data (when creating new a new one).
 Each of the common fields corresponds to one private field in \code{FilterState}
 where it is stored and from where it is retrieved when calling \code{FiterState$get_state}.
 
 A \code{teal_slice} can also contain any number of additional fields, passed to \code{...}
 as \code{name:value} pairs. These are collated into a list and stored in the
-\code{private$extras} field.
+\code{private$extras} field in \code{FilterState}.
 
 All \code{teal_slice} fields can be passed as arguments to \code{FilterState} constructors.
 A \code{teal_slice} can be passed to \code{FilterState$set_state}, which will modify the state.
 However, once a \code{FilterState} is created, only the \strong{mutable} features can be set with a \code{teal_slice}:
 \code{selected}, \code{keep_na}, \code{keep_inf}, and \code{disabled}.
 
-Special consideration is given to the \code{fixed} field. This is always a logical flag that defaults to FALSE.
+Special consideration is given to two fields: \code{fixed} and \code{locked}.
+These are always immutable logical flags that default to FALSE.
 In a \code{FilterState} instantiated with \code{fixed = TRUE} the features \code{selected}, \code{keep_na}, \code{keep_inf}
-cannot be changed but the\code{disabled} can.
+cannot be changed but the \code{disabled} feature can.
+A \code{FilterState} instantiated with \code{locked = TRUE} cannot be disabled or removed.
+Any combination of \code{fixed} and \code{locked} is permitted.
 
 \code{filter_var} creates a \code{teal_slice} object, which specifies a filter for a single variable,
 passed to and resolved by \code{FilterState} objects.
@@ -172,6 +175,11 @@ a complete filter specification. This is used by all classes above \code{FilterS
 as well as \code{filter_panel_api} wrapper functions.
 \code{teal_slices} also specifies which variables cannot be filtered
 and how observations are tallied, which is resolved by \code{FilterStates}.
+
+\code{include_varnames} and \code{exclude_varnames} in attributes in \code{teal_slices}
+determine which variables can have filters assigned.
+The former enumerates allowed variables, the latter enumerates forbidden values.
+Since these can be mutually exclusive in some cases, they cannot both be set in one \code{teal_slices} object.
 }
 \section{Filters in \code{SumarizedExperiment} and \code{MultiAssayExperiment} objects}{
 

--- a/tests/testthat/test-ChoicesFilterState.R
+++ b/tests/testthat/test-ChoicesFilterState.R
@@ -390,8 +390,9 @@ testthat::test_that("format shortens names if strings are too long", {
       " $ choices : exceedingly long value nam...",
       " $ multiple: TRUE",
       " $ selected: exceedinglylongvaluenameex...",
+      " $ disabled: FALSE",
       " $ fixed   : FALSE",
-      " $ disabled: FALSE\n",
+      " $ locked  : FALSE\n",
       sep = "\n"
     )
   )

--- a/tests/testthat/test-DefaultFilteredDataset.R
+++ b/tests/testthat/test-DefaultFilteredDataset.R
@@ -39,12 +39,12 @@ testthat::test_that("set_filter_state sets `teal_slice`", {
   fs <- filter_settings(
     filter_var(
       dataname = "iris", varname = "Sepal.Length", choices = c(4.3, 7.9), selected = c(5.1, 6.4),
-      keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, disabled = FALSE
+      keep_na = FALSE, keep_inf = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE
     ),
     filter_var(
       dataname = "iris", varname = "Species",
       choices = c("setosa", "versicolor", "virginica"), multiple = TRUE, selected = c("setosa", "versicolor"),
-      keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, disabled = FALSE
+      keep_na = FALSE, keep_inf = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE
     ),
     count_type = "all",
     include_varnames = list(iris = colnames(iris))
@@ -56,18 +56,19 @@ testthat::test_that("set_filter_state sets `teal_slice`", {
   )
 })
 
+
 # format ---
 testthat::test_that("format returns a properly formatted string representation", {
   dataset <- DefaultFilteredDataset$new(dataset = iris, dataname = "iris")
   fs <- filter_settings(
     filter_var(
       dataname = "iris", varname = "Sepal.Length", choices = c(4.3, 7.9), selected = c(5.1, 6.4),
-      keep_inf = FALSE, fixed = FALSE, disabled = FALSE
+      keep_inf = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE
     ),
     filter_var(
       dataname = "iris", varname = "Species",
       choices = c("setosa", "versicolor", "virginica"), selected = c("setosa", "versicolor"),
-      keep_na = FALSE, fixed = FALSE, disabled = FALSE
+      keep_na = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE
     ),
     count_type = "all",
     include_varnames = list(iris = colnames(iris))
@@ -95,12 +96,12 @@ testthat::test_that("print returns a properly formatted string representation", 
   fs <- filter_settings(
     filter_var(
       dataname = "iris", varname = "Sepal.Length", choices = c(4.3, 7.9), selected = c(5.1, 6.4),
-      keep_inf = FALSE, fixed = FALSE, disabled = FALSE
+      keep_inf = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE
     ),
     filter_var(
       dataname = "iris", varname = "Species",
       choices = c("setosa", "versicolor", "virginica"), selected = c("setosa", "versicolor"),
-      keep_na = FALSE, fixed = FALSE, disabled = FALSE
+      keep_na = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE
     ),
     count_type = "all",
     include_varnames = list(iris = colnames(iris))

--- a/tests/testthat/test-FilterState.R
+++ b/tests/testthat/test-FilterState.R
@@ -33,12 +33,16 @@ testthat::test_that("constructor checks arguments", {
     "Assertion on 'keep_inf' failed"
   )
   testthat::expect_error(
+    FilterState$new(x = 7, dataname = "data", varname = "variable", disabled = NULL),
+    "Assertion on 'disabled' failed"
+  )
+  testthat::expect_error(
     FilterState$new(x = 7, dataname = "data", varname = "variable", fixed = NULL),
     "Assertion on 'fixed' failed"
   )
   testthat::expect_error(
-    FilterState$new(x = 7, dataname = "data", varname = "variable", disabled = NULL),
-    "Assertion on 'disabled' failed"
+    FilterState$new(x = 7, dataname = "data", varname = "variable", locked = NULL),
+    "Assertion on 'locked' failed"
   )
   testthat::expect_error(
     FilterState$new(x = 7, dataname = "data", varname = "variable", extract_type = "other"),
@@ -111,6 +115,54 @@ testthat::test_that("set_state cannot set mutable fields in a fixed FilterState"
   )
   testthat::expect_output(filter_state$set_state(new_state), "WARN.+attempt to set state on fixed filter")
   testthat::expect_identical(shiny::isolate(filter_state$get_state()), old_state)
+})
+
+testthat::test_that("set_state can set mutable fields in a locked FilterState", {
+  filter_state <- FilterState$new(c("a", NA_character_), dataname = "data", varname = "variable", locked = TRUE)
+  old_state <- shiny::isolate(filter_state$get_state())
+  new_state <- filter_var(
+    dataname = "data",
+    varname = "variable",
+    selected = "a",
+    keep_na = TRUE,
+    keep_inf = FALSE,
+    disabled = FALSE,
+    locked = TRUE
+  )
+  testthat::expect_output(filter_state$set_state(new_state), "WARN.+attempt to disable a locked filter aborted")
+  testthat::expect_identical(shiny::isolate(filter_state$get_state()), new_state)
+})
+
+testthat::test_that("set_state cannot set disabled field in a locked FilterState", {
+  filter_state <- FilterState$new(c("a", NA_character_), dataname = "data", varname = "variable", locked = TRUE)
+  new_state <- filter_var(
+    dataname = "data",
+    varname = "variable",
+    selected = "a",
+    keep_na = TRUE,
+    keep_inf = FALSE,
+    disabled = FALSE,
+    locked = TRUE
+  )
+  testthat::expect_output(filter_state$set_state(new_state), "WARN.+attempt to disable a locked filter aborted")
+})
+
+testthat::test_that("set_state overrides disabled field to FALSE when filter changes to locked at FilterState", {
+  filter_state <- FilterState$new(
+    c("a", NA_character_),
+    dataname = "data", varname = "variable",
+    locked = FALSE, disabled = TRUE
+  )
+  new_state <- filter_var(
+    dataname = "data",
+    varname = "variable",
+    selected = "a",
+    keep_na = TRUE,
+    keep_inf = FALSE,
+    locked = TRUE
+  )
+  filter_state$set_state(new_state)
+  testthat::expect_false(shiny::isolate(filter_state$get_state())$disabled)
 })
 
 testthat::test_that("set_state cannot set mutable fields in a disabled FilterState", {

--- a/tests/testthat/test-FilterStates.R
+++ b/tests/testthat/test-FilterStates.R
@@ -54,7 +54,7 @@ testthat::test_that("set_filter_state and get_filter_state, sets and returns the
   fs <- filter_settings(
     filter_var(
       dataname = "test", varname = "a", choices = c(1, 5), selected = c(1, 4), keep_na = FALSE, keep_inf = FALSE,
-      fixed = FALSE, disabled = FALSE,
+      disabled = FALSE, fixed = FALSE, locked = FALSE,
       any_attribute = "a", another_attribute = "b"
     ),
     count_type = "none"
@@ -72,7 +72,7 @@ existing filter", {
   fs <- filter_settings(
     filter_var(
       dataname = "test", varname = "a", choices = c(1, 5), selected = c(1, 4), keep_na = FALSE, keep_inf = FALSE,
-      fixed = FALSE, disabled = FALSE, any_attribute = "a", another_attribute = "b"
+      disabled = FALSE, fixed = FALSE, locked = FALSE, any_attribute = "a", another_attribute = "b"
     ),
     count_type = "none"
   )
@@ -381,16 +381,16 @@ testthat::test_that("Adding 'var_to_add' adds another filter state", {
     filter_settings(
       filter_var(
         dataname = "iris", varname = "Sepal.Length", choices = c(4.3, 7.9), selected = c(5.1, 6.4),
-        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, disabled = FALSE
+        keep_na = FALSE, keep_inf = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE
       ),
       filter_var(
         dataname = "iris", varname = "Petal.Length", choices = c(1.0, 6.9), selected = c(1.0, 6.9),
-        keep_na = NULL, keep_inf = NULL, fixed = FALSE, disabled = FALSE
+        keep_na = NULL, keep_inf = NULL, disabled = FALSE, fixed = FALSE, locked = FALSE
       ),
       filter_var(
         dataname = "iris", varname = "Species", choices = c("setosa", "versicolor", "virginica"),
-        multiple = TRUE, selected = c("setosa", "versicolor", "virginica"), keep_na = NULL,
-        keep_inf = NULL, fixed = FALSE, disabled = FALSE
+        multiple = TRUE, selected = c("setosa", "versicolor", "virginica"), keep_na = NULL, keep_inf = NULL,
+        disabled = FALSE, fixed = FALSE, locked = FALSE
       ),
       count_type = "all"
     )

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -631,6 +631,39 @@ testthat::test_that("remove_filter_state removes states specified by `teal_slice
   testthat::expect_identical(slices_field(shiny::isolate(datasets$get_filter_state()), "varname"), "Species")
 })
 
+testthat::test_that("remove_filter_state does not remove locked filters", {
+  datasets <- teal.slice:::FilteredData$new(
+    list(
+      iris = list(dataset = iris),
+      mtcars = list(dataset = mtcars, metadata = list(type = "training"))
+    )
+  )
+  fs <- filter_settings(
+    filter_var(
+      dataname = "iris", varname = "Sepal.Length", selected = c(5.1, 6.4),
+      keep_na = FALSE, keep_inf = FALSE
+    ),
+    filter_var(
+      dataname = "iris", varname = "Species", selected = c("setosa", "versicolor"),
+      keep_na = FALSE, locked = TRUE
+    ),
+    filter_var(
+      dataname = "iris", varname = "Sepal.Width", selected = c(2.5, 3.3),
+      keep_na = FALSE, keep_inf = FALSE, locked = TRUE
+    )
+  )
+  datasets$set_filter_state(state = fs)
+
+  state <- fs[1:2]
+
+  datasets$remove_filter_state(state)
+
+  testthat::expect_length(shiny::isolate(datasets$get_filter_state()), 2)
+  testthat::expect_true(
+    teal.slice:::slices_field(shiny::isolate(datasets$get_filter_state()), "locked")
+  )
+})
+
 
 # clear_filter_states ----
 testthat::test_that("clear_filter_states removes all filters of all datasets in FilteredData", {
@@ -671,6 +704,36 @@ testthat::test_that("clear_filter_states removes filters of desired dataset only
   testthat::expect_identical(slices_field(shiny::isolate(datasets$get_filter_state()), "dataname"), "mtcars")
 })
 
+testthat::test_that("clear_filter_states does not remove locked filters", {
+  datasets <- teal.slice:::FilteredData$new(
+    list(
+      iris = list(dataset = iris),
+      mtcars = list(dataset = mtcars, metadata = list(type = "training"))
+    )
+  )
+  fs <- filter_settings(
+    filter_var(
+      dataname = "iris", varname = "Sepal.Length", selected = c(5.1, 6.4),
+      keep_na = FALSE, keep_inf = FALSE
+    ),
+    filter_var(
+      dataname = "iris", varname = "Species", selected = c("setosa", "versicolor"),
+      keep_na = FALSE, locked = TRUE
+    ),
+    filter_var(
+      dataname = "iris", varname = "Sepal.Width", selected = c(2.5, 3.3),
+      keep_na = FALSE, keep_inf = FALSE, locked = TRUE
+    )
+  )
+  datasets$set_filter_state(state = fs)
+
+  datasets$clear_filter_states()
+
+  testthat::expect_length(shiny::isolate(datasets$get_filter_state()), 2)
+  testthat::expect_true(
+    teal.slice:::slices_field(shiny::isolate(datasets$get_filter_state()), "locked")
+  )
+})
 
 # get_filter_overview ----
 testthat::test_that("get_filter_overview checks arguments", {

--- a/tests/testthat/test-MAEFilteredDataset.R
+++ b/tests/testthat/test-MAEFilteredDataset.R
@@ -272,19 +272,23 @@ testthat::test_that(
     fs <- filter_settings(
       filter_var(
         dataname = "miniacc", varname = "years_to_birth", choices = c(14, 83), selected = c(30, 50),
-        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, disabled = FALSE, datalabel = "subjects", arg = "y"
+        keep_na = FALSE, keep_inf = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE,
+        datalabel = "subjects", arg = "y"
       ),
       filter_var(
         dataname = "miniacc", varname = "vital_status", choices = c("0", "1"), multiple = TRUE, selected = "1",
-        keep_na = FALSE, keep_inf = NULL, fixed = FALSE, disabled = FALSE, datalabel = "subjects", arg = "y"
+        keep_na = FALSE, keep_inf = NULL, disabled = FALSE, fixed = FALSE, locked = FALSE,
+        datalabel = "subjects", arg = "y"
       ),
       filter_var(
         dataname = "miniacc", varname = "gender", choices = c("female", "male"), multiple = TRUE, selected = "female",
-        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, disabled = FALSE, datalabel = "subjects", arg = "y"
+        keep_na = FALSE, keep_inf = FALSE, disabled = FALSE, fixed = FALSE, locked = FALSE,
+        datalabel = "subjects", arg = "y"
       ),
       filter_var(
         dataname = "miniacc", varname = "ARRAY_TYPE", choices = c("", "protein_level"), multiple = TRUE, selected = "",
-        keep_na = FALSE, keep_inf = NULL, fixed = FALSE, disabled = FALSE, datalabel = "RPPAArray", arg = "subset"
+        keep_na = FALSE, keep_inf = NULL, disabled = FALSE, fixed = FALSE, locked = FALSE,
+        datalabel = "RPPAArray", arg = "subset"
       ),
       count_type = "none",
       include_varnames = list(miniacc = colnames(SummarizedExperiment::colData(miniACC)))

--- a/tests/testthat/test-init_filter_state.R
+++ b/tests/testthat/test-init_filter_state.R
@@ -33,12 +33,16 @@ testthat::test_that("init_filter_state checks arguments", {
     "Assertion on 'keep_inf' failed"
   )
   testthat::expect_error(
+    init_filter_state(x = 7, dataname = "data", varname = "variable", disabled = NULL),
+    "Assertion on 'disabled' failed"
+  )
+  testthat::expect_error(
     init_filter_state(x = 7, dataname = "data", varname = "variable", fixed = NULL),
     "Assertion on 'fixed' failed"
   )
   testthat::expect_error(
-    init_filter_state(x = 7, dataname = "data", varname = "variable", disabled = NULL),
-    "Assertion on 'disabled' failed"
+    init_filter_state(x = 7, dataname = "data", varname = "variable", locked = NULL),
+    "Assertion on 'locked' failed"
   )
   testthat::expect_error(
     init_filter_state(x = 7, dataname = "data", varname = "variable", extract_type = "other"),

--- a/tests/testthat/test-teal_slice.R
+++ b/tests/testthat/test-teal_slice.R
@@ -11,7 +11,37 @@ testthat::test_that("filter_var checks arguments", {
       keep_na = NULL,
       keep_inf = NULL,
       fixed = FALSE,
+      locked = FALSE,
       disabled = FALSE
+    )
+  )
+
+  testthat::expect_no_error(
+    filter_var(
+      dataname = "data",
+      varname = "var",
+      choices = NULL,
+      selected = NULL,
+      keep_na = NULL,
+      keep_inf = NULL,
+      fixed = FALSE,
+      locked = TRUE,
+      disabled = FALSE
+    )
+  )
+
+
+  testthat::expect_no_error(
+    filter_var(
+      dataname = "data",
+      varname = "var",
+      choices = NULL,
+      selected = NULL,
+      keep_na = NULL,
+      keep_inf = NULL,
+      fixed = TRUE,
+      locked = TRUE,
+      disabled = TRUE
     )
   )
 
@@ -65,6 +95,15 @@ testthat::test_that("filter_var checks arguments", {
   )
 
   testthat::expect_error(
+    filter_var(dataname = "data", varname = "var", disabled = NULL),
+    "Assertion on 'disabled' failed"
+  )
+  testthat::expect_error(
+    filter_var(dataname = "data", varname = "var", disabled = "TRUE"),
+    "Assertion on 'disabled' failed"
+  )
+
+  testthat::expect_error(
     filter_var(dataname = "data", varname = "var", fixed = NULL),
     "Assertion on 'fixed' failed"
   )
@@ -74,12 +113,12 @@ testthat::test_that("filter_var checks arguments", {
   )
 
   testthat::expect_error(
-    filter_var(dataname = "data", varname = "var", disabled = NULL),
-    "Assertion on 'disabled' failed"
+    filter_var(dataname = "data", varname = "var", locked = NULL),
+    "Assertion on 'locked' failed"
   )
   testthat::expect_error(
-    filter_var(dataname = "data", varname = "var", disabled = "TRUE"),
-    "Assertion on 'disabled' failed"
+    filter_var(dataname = "data", varname = "var", locked = "TRUE"),
+    "Assertion on 'locked' failed"
   )
 })
 
@@ -92,7 +131,7 @@ testthat::test_that("filter_var returns `teal_slice`", {
   testthat::expect_failure(
     testthat::expect_s3_class(fs1, "teal_slices")
   )
-  testthat::expect_length(fs1, 9L)
+  testthat::expect_length(fs1, 10L)
 })
 
 
@@ -467,7 +506,9 @@ testthat::test_that("slices_field works", {
   testthat::expect_identical(slices_field(fs, "dataname"), "data")
   testthat::expect_identical(slices_field(fs, "varname"), c("var1", "var2"))
   testthat::expect_identical(slices_field(fs, "choices"), NULL)
+  testthat::expect_identical(slices_field(fs, "disabled"), FALSE)
   testthat::expect_identical(slices_field(fs, "fixed"), FALSE)
+  testthat::expect_identical(slices_field(fs, "locked"), FALSE)
 })
 
 


### PR DESCRIPTION
Closes #280 

Adds a `locked` property to `FilterState` class. A locked filter state cannot be disabled or removed but can still be modified. `locked` and `fixed` properties can be set independently of one another.

Changes to `FilterState` class:
* `locked` argument is added to constructors and wrappers; the argument receives a logical flag and defaults to `FALSE`
* a private field `locked` is added to `FilterState` to store the property
* `$get_state` is modified to return the `locked` value in addition to all other filter state properties
* `$set state` is modified to interrupt an attempt at disabling a filter state that is locked
* `$ui` is modified to only display the disable and remove buttons if `private$locked` is `FALSE`
* `$ui` is modified to display an additional icon if `private$locked` is `TRUE`

Analogous changes are made to `FilterStateExpr` class.

The `locked` argument is also added to `filter_var`.

Furthermore, `FilteredData$filter_panel_disable` and `FilteredData$filter_panel_disable` are modified so that locked filter states ignore the global disable button. To this end, disabling the div containing all filter cards ("filter_active_vars_contents") is removed. Filter cards are now disabled solely by setting their state with `disabled = TRUE` (which locked states ignore).



Remaining actions:
1. Modify `FilterStates$remove_filter_state` and `FilterStates$clear_filter_states` so that locked filter states are omitted.
2. Establish whether the behavior in response to the global disable action is as required. The code in `FilteredData$filter_panel_enable/disable` has not been removed but commented out and marked with "TODO".
3. The `lock` icon has been transferred from the `fixed` property to the `locked` property. A fixed state thus needs a new icon. `burst` is used as a placeholder but a suitable replacement must be found.
4. Unit tests must be amended.
