### PR TITLE
306 fix tests after different deparse for teal_slize (287)

### DIFF
--- a/tests/testthat/test-ChoicesFilterState.R
+++ b/tests/testthat/test-ChoicesFilterState.R
@@ -345,10 +345,10 @@ testthat::test_that("format shortens names if strings are too long", {
     paste(
       "ChoicesFilterState:",
       "teal_slice",
-      " $ dataname: \"data\"",
-      " $ varname : \"variable\"",
-      " $ choices : c(\"exceedingly long value ...",
-      " $ selected: c(\"exceedinglylongvaluenam...",
+      " $ dataname: data",
+      " $ varname : variable",
+      " $ choices : exceedingly long value nam...",
+      " $ selected: exceedinglylongvaluenameex...",
       " $ fixed   : FALSE",
       " $ disabled: FALSE\n",
       sep = "\n"


### PR DESCRIPTION
close #306 

Hey @chlebowa assigning you for the review, so just you know that #287 introduced a crash in tests, but I think you merged #287 before we merged new tests for `$format()` method with #281 