### PR TITLE
309 - shorten line widths for FilterState* tests

### DIFF
--- a/tests/testthat/test-ChoicesFilterState.R
+++ b/tests/testthat/test-ChoicesFilterState.R
@@ -311,9 +311,18 @@ testthat::test_that("format accepts logical show_all", {
   filter_state <- ChoicesFilterState$new(7, dataname = "data", varname = "variable")
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = TRUE)))
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = FALSE)))
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 1)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 0)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = "TRUE")), "Assertion on 'show_all' failed")
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 1)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 0)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = "TRUE")),
+    "Assertion on 'show_all' failed"
+  )
 })
 
 testthat::test_that("format returns properly formatted string representation", {

--- a/tests/testthat/test-DateFilterState.R
+++ b/tests/testthat/test-DateFilterState.R
@@ -229,9 +229,18 @@ testthat::test_that("format accepts logical show_all", {
   filter_state <- DateFilterState$new(dates, dataname = "data", varname = "variable")
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = TRUE)))
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = FALSE)))
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 1)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 0)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = "TRUE")), "Assertion on 'show_all' failed")
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 1)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 0)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = "TRUE")),
+    "Assertion on 'show_all' failed"
+  )
 })
 
 testthat::test_that("format returns a properly formatted string representation", {

--- a/tests/testthat/test-DatetimeFilterState.R
+++ b/tests/testthat/test-DatetimeFilterState.R
@@ -244,9 +244,18 @@ testthat::test_that("format accepts logical show_all", {
   filter_state <- DatetimeFilterState$new(posixct, dataname = "data", varname = "variable")
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = TRUE)))
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = FALSE)))
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 1)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 0)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = "TRUE")), "Assertion on 'show_all' failed")
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 1)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 0)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = "TRUE")),
+    "Assertion on 'show_all' failed"
+  )
 })
 
 testthat::test_that("format returns a properly formatted string representation", {

--- a/tests/testthat/test-EmptyFilterState.R
+++ b/tests/testthat/test-EmptyFilterState.R
@@ -22,9 +22,18 @@ testthat::test_that("format accepts logical show_all", {
   filter_state <- EmptyFilterState$new(NA, dataname = "data", varname = "variable", keep_na = FALSE, disabled = TRUE)
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = TRUE)))
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = FALSE)))
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 1)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 0)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = "TRUE")), "Assertion on 'show_all' failed")
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 1)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 0)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = "TRUE")),
+    "Assertion on 'show_all' failed"
+  )
 })
 
 testthat::test_that("format returns a properly formatted string representation", {

--- a/tests/testthat/test-FilterState.R
+++ b/tests/testthat/test-FilterState.R
@@ -326,9 +326,18 @@ testthat::test_that("format accepts logical show_all", {
   filter_state <- FilterState$new(7, dataname = "data", varname = "7")
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = TRUE)))
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = FALSE)))
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 1)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 0)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = "TRUE")), "Assertion on 'show_all' failed")
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 1)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 0)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = "TRUE")),
+    "Assertion on 'show_all' failed"
+  )
 })
 
 

--- a/tests/testthat/test-LogicalFilterState.R
+++ b/tests/testthat/test-LogicalFilterState.R
@@ -114,9 +114,18 @@ testthat::test_that("format accepts logical show_all", {
   filter_state <- LogicalFilterState$new(logs, dataname = "data", varname = "variable")
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = TRUE)))
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = FALSE)))
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 1)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 0)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = "TRUE")), "Assertion on 'show_all' failed")
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 1)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 0)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = "TRUE")),
+    "Assertion on 'show_all' failed"
+  )
 })
 
 testthat::test_that("format returns a properly formatted string representation", {

--- a/tests/testthat/test-RangeFilterState.R
+++ b/tests/testthat/test-RangeFilterState.R
@@ -266,9 +266,18 @@ testthat::test_that("format accepts logical show_all", {
   filter_state <- RangeFilterState$new(nums, dataname = "data", varname = "variable")
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = TRUE)))
   testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = FALSE)))
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 1)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = 0)), "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'")
-  testthat::expect_error(shiny::isolate(filter_state$format(show_all = "TRUE")), "Assertion on 'show_all' failed")
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 1)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 0)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = "TRUE")),
+    "Assertion on 'show_all' failed"
+  )
 })
 
 testthat::test_that("format returns a properly formatted string representation", {


### PR DESCRIPTION
fix #309 
Make test lines shorten than 120 characters. This is required with lintr check