### PR TITLE
311 - missing internal @keyword for get_teal_slice_id

### DIFF
--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -527,6 +527,8 @@ slices_which <- function(tss, expr) {
 #' Hash is obtained from fields which determines single filter-state.
 #' @param x (`teal_slice`, `teal_slice_expr`) single `teal_slice` object
 #' @return `character(1)`
+#' @keywords internal
+#'
 get_teal_slice_id <- function(x) {
   rlang::hash(
     x[c("dataname", "datalabel", "arg", "id", "varname")]


### PR DESCRIPTION
Hey @gogonzo assigning you on this one, as this is something that fixes Docs builds after you merged #262 
You can see more context on #311 that gets fixed with this change, but high level overview is that pkgdown was unable to provide a topic for this `get_teal_slice_id()` function.