### PR TITLE
extend check and docs github workflows with a trigger on filter_panel_refactor branch

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,9 +10,11 @@ on:
       - ready_for_review
     branches:
       - main
+      - filter_panel_refactor
   push:
     branches:
       - main
+      - filter_panel_refactor
   workflow_dispatch:
 
   # Rerun workflows once pkgdown has finished running, to add coverage

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - filter_panel_refactor
     paths:
       - "inst/templates/**"
       - "_pkgdown.y[a]ml"
@@ -22,6 +23,7 @@ on:
       - ready_for_review
     branches:
       - main
+      - filter_panel_refactor
     paths:
       - "inst/templates/**"
       - "_pkgdown.y[a]ml"


### PR DESCRIPTION
One of actions we aligned on during this discussion https://github.com/insightsengineering/teal.slice/discussions/313 was to setup automated testing for branches that for a longer time substituted main branch. In this case it's `filter_panel_refactor` branch. 