### PR TITLE
341 available locked@filter panel refactor@main

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     checkmate,
     dplyr,
     grDevices,
+    htmltools,
     lifecycle,
     logger (>= 0.2.0),
     methods,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -37,6 +37,7 @@
 .rectify_dependencies_check <- function() {
   dplyr::filter
   grDevices::rgb
+  htmltools::tagInsertChildren
   lifecycle::badge
   logger::log_trace
   plotly::plot_ly

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -359,9 +359,13 @@ a.remove_all:hover {
 }
 
 .popover-header {
-    margin-top: 0em;
+  margin-top: 0em;
 }
 
 .popover-body {
-    margin-bottom: -1rem;
+  margin-bottom: -1rem;
+}
+
+.available-filters {
+  margin-top: 0em;
 }

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -927,9 +927,10 @@ test_class <- R6::R6Class(
 datasets <- test_class$new(list(iris = list(dataset = iris)))
 fs <- filter_settings(
   filter_var(dataname = "iris", varname = "Sepal.Length", locked = TRUE),
-  filter_var(dataname = "iris", varname = "Sepal.Width"),
+  filter_var(dataname = "iris", varname = "Sepal.Width", fixed = TRUE),
   filter_var(dataname = "iris", varname = "Petal.Length"),
-  filter_var(dataname = "iris", varname = "Petal.Width")
+  filter_var(dataname = "iris", varname = "Petal.Width"),
+  filter_expr(dataname = "iris", title = "test", id = "test", expr = "!is.na(Species)")
 )
 fs_rv <- reactiveVal(fs)
 datasets$set_available_teal_slices(reactive(fs_rv()))
@@ -937,6 +938,12 @@ datasets$set_filter_state(fs[1:2])
 shiny::testServer(
   datasets$srv_available_filters,
   expr = {
+    testthat::test_that("slices_interactive() reactive returns interactive filters", {
+      expect_identical_slices(slices_interactive(), fs[c(1, 3, 4)])
+    })
+    testthat::test_that("slices_fixed() reactive returns fixed filters and teal_slice_expr", {
+      expect_identical_slices(slices_fixed(), fs[c(2, 5)])
+    })
     testthat::test_that("FilteredData$srv_available_slices locked slices ommited", {
       testthat::expect_identical(slices(), fs[-1])
     })
@@ -946,7 +953,7 @@ shiny::testServer(
       fs_rv(c(fs_rv(), filter_settings(species_slice)))
       testthat::expect_identical(
         available_slices_id(),
-        c("iris Sepal.Width", "iris Petal.Length", "iris Petal.Width", "iris Species")
+        c("iris Sepal.Width", "iris Petal.Length", "iris Petal.Width", "test", "iris Species")
       )
     })
 


### PR DESCRIPTION
Fixes #341 

Now so called "quick add" or "available filters" displays also locked filters. Locked filters are disabled and not able to change. 
On the image below one can see first two filters being locked.

<img width="358" alt="Skärmavbild 2023-06-16 kl  16 22 21" src="https://github.com/insightsengineering/teal.slice/assets/6959016/d7244e91-ee26-4f50-9bac-3b19d90bf717">

Example app

```r
options(teal.log_level = "TRACE", teal.show_js_log = TRUE)
# options("teal.bs_theme" = bslib::bs_theme(version = 5))
# options(shiny.trace = TRUE)
# todo: change groupCheckbox to include locked (not able to interact with)
#       change groupCheckbox to have some colors (instead of grey)
# todo: available filter should present information about selected values (for example tooltip)

library(shiny)
library(scda)
library(scda.2022)
library(teal.data)
library(teal.transform)
library(teal.modules.general)
pkgload::load_all("teal")
pkgload::load_all("teal.slice")

funny_module <- function (label = "Filter states", datanames = "all") {
  checkmate::assert_string(label)
  module(
    label = label,
    filters = datanames,
    ui = function(id, ...) {
      ns <- NS(id)
      div(
        h2("The following filter calls are generated:"),
        verbatimTextOutput(ns("filter_states")),
        verbatimTextOutput(ns("filter_calls")),
        actionButton(ns("reset"), "reset_to_default")
      )
    },
    server = function(input, output, session, data, filter_panel_api) {
      checkmate::assert_class(data, "tdata")
      observeEvent(input$reset, set_filter_state(filter_panel_api, default_filters))
      output$filter_states <-  renderPrint({
        logger::log_trace("rendering text1")
        filter_panel_api %>% get_filter_state()
      })
      output$filter_calls <- renderText({
        logger::log_trace("rendering text2")
        attr(data, "code")()
      })
    }
  )
}

ADSL <- synthetic_cdisc_data("latest")$adsl
ADSL$empty <- NA
ADSL$logical1 <- FALSE
ADSL$logical <- sample(c(TRUE, FALSE), size = nrow(ADSL), replace = TRUE)
ADSL$numeric <- rnorm(nrow(ADSL))
ADSL$categorical2 <- sample(letters[1:10], size = nrow(ADSL), replace = TRUE)
ADSL$categorical <- sample(letters[1:3], size = nrow(ADSL), replace = TRUE, prob = c(.1, .3, .6))
ADSL$date <- Sys.Date() + seq_len(nrow(ADSL))
ADSL$date2 <- rep(Sys.Date() + 1:3, length.out = nrow(ADSL))
ADSL$datetime <- Sys.time() + seq_len(nrow(ADSL)) * 3600 * 12
ADSL$datetime2 <- rep(Sys.time() + 1:3 * 43200, length.out = nrow(ADSL))

ADSL$numeric[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$numeric[sample(1:nrow(ADSL), size = 10)] <- Inf
ADSL$logical[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$date[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$datetime[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$categorical2[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$categorical[sample(1:nrow(ADSL), size = 10)] <- NA

ADTTE <- synthetic_cdisc_data("latest")$adtte
ADRS <- synthetic_cdisc_data("latest")$adrs

ADTTE$numeric <- rnorm(nrow(ADTTE))
ADTTE$numeric[sample(1:nrow(ADTTE), size = 10,)] <- NA

default_filters <- teal::teal_filters(
  filter_var(dataname = "ADSL", varname = "categorical", selected = c("a", "b"), id = "categorical", locked = TRUE),
  filter_var(dataname = "ADSL", varname = "categorical2", selected = c("a", "b"), locked = TRUE),
  filter_var(dataname = "ADSL", varname = "numeric", selected = c(0, 140), keep_na = TRUE, keep_inf = TRUE),
  filter_var(dataname = "ADSL", varname = "logical", selected = c(T), keep_na = TRUE, keep_inf = TRUE),
  filter_var(dataname = "ADSL", varname = "datetime"),
  filter_var(dataname = "ADSL", varname = "date2"),
  filter_expr(id = "AF", title = "ADULT FEMALE", dataname = "ADSL", expr = "SEX %in% 'F' & AGE >= 18L"),
  filter_expr(id = "SE", title = "Safety-Evaluable", dataname = "ADSL", expr = "SAFFL == 'Y'"),
  filter_var(dataname = "ADSL", varname = "COUNTRY", selected = c("USA", "CAN", "JPN"), fixed = TRUE),
  count_type = "all",
  include_varnames = list(ADSL = c("SEX", "categorical", "categorical2", "numeric", "logical", "date", "datetime", "date2", "datetime2", "COUNTRY")),
  exclude_varnames = list(
    ADTTE = intersect(colnames(ADSL), colnames(ADTTE)),
    ADRS = colnames(ADSL)
  ),
  mapping = list(
    `table` = "categorical"
  ),
  module_specific = TRUE
)

app <- init(
  data = cdisc_data(
    cdisc_dataset("ADSL", ADSL),
    cdisc_dataset("ADTTE", ADTTE),
    cdisc_dataset("ADRS", ADRS)
  ),
  modules = modules(
    tm_data_table(
      "table",
      variables_selected = list(ADSL = c("STUDYID", "USUBJID", "SUBJID", "SITEID", "AGE", "SEX")),
      dt_args = list(caption = "ADSL Table Caption")
    ),
    modules(
      label = "tab1",
      funny_module("funny", datanames = NULL),
      funny_module("funny2", datanames = "ADTTE") # will limit datanames to ADTTE and ADSL (parent)
    )
  ),
  filter = default_filters
)


runApp(app)
```