### PR TITLE
Fix when no choices available in module_add

### DIFF
--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -454,7 +454,7 @@ FilterStates <- R6::R6Class( # nolint
             logger::log_trace(
               "FilterStates$srv_add@1 updating available column choices, dataname: { private$dataname }"
             )
-            if (is.null(avail_column_choices())) {
+            if (length(avail_column_choices()) == 0) {
               span("No available columns to add.")
             } else {
               div(


### PR DESCRIPTION
Fixes #346 


<img width="375" alt="Skärmavbild 2023-06-21 kl  07 38 13" src="https://github.com/insightsengineering/teal.slice/assets/6959016/dd3fa31a-e72a-4054-a984-e49364020430">


```r
pkgload::load_all("teal.slice")
library(teal)

app <- init(
  filter = filter_settings(
    filter_var(dataname = "iris", varname = "Sepal.Length"),
    filter_var(dataname = "iris", varname = "Sepal.Width"),
    filter_var(dataname = "iris", varname = "Petal.Length"),
    filter_var(dataname = "iris", varname = "Petal.Width"),
    filter_var(dataname = "iris", varname = "Species")
  ),
  data = teal_data(
    dataset("iris", iris),
    dataset("mtcars", mtcars)
  ),
  modules = modules(example_module()),
  header = "My first teal application"
)

shinyApp(app$ui, app$server)

```