### PR TITLE
Rename `datalabel` to `experiment`

### DIFF
--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -325,7 +325,7 @@ FilterStates <- R6::R6Class( # nolint
         uiOutput(
           ns("cards"),
           class = "accordion",
-          `data-label` = ifelse(length(private$datalabel), "", paste0("> ", private$datalabel)),
+          `data-label` = ifelse(length(private$datalabel), paste0("> ", private$datalabel), ""),
         )
       )
     },
@@ -483,7 +483,7 @@ FilterStates <- R6::R6Class( # nolint
               )
               self$set_filter_state(
                 filter_settings(
-                  filter_var(dataname = private$dataname, varname = input$var_to_add, datalabel = private$datalabel)
+                  filter_var(dataname = private$dataname, varname = input$var_to_add)
                 )
               )
               logger::log_trace(

--- a/R/FilterStatesMAE.R
+++ b/R/FilterStatesMAE.R
@@ -46,35 +46,6 @@ MAEFilterStates <- R6::R6Class( # nolint
       private$keys <- keys
       private$set_filterable_varnames(include_varnames = colnames(data))
       return(invisible(self))
-    },
-
-    # shiny modules ----
-
-    #' @description
-    #' Shiny UI module to add filter variable
-    #' @param id (`character(1)`)\cr
-    #'  id of shiny module
-    #' @return shiny.tag
-    ui_add = function(id) {
-      data <- private$data
-      checkmate::assert_string(id)
-
-      ns <- NS(id)
-
-      if (ncol(data) == 0) {
-        div("no sample variables available")
-      } else if (nrow(data) == 0) {
-        div("no samples available")
-      } else {
-        teal.widgets::optionalSelectInput(
-          ns("var_to_add"),
-          choices = NULL,
-          options = shinyWidgets::pickerOptions(
-            liveSearch = TRUE,
-            noneSelectedText = "Select subject variable"
-          )
-        )
-      }
     }
   ),
 

--- a/R/FilterStatesMatrix.R
+++ b/R/FilterStatesMatrix.R
@@ -24,7 +24,7 @@ MatrixFilterStates <- R6::R6Class( # nolint
     #'   name of the data used in the expression
     #'   specified to the function argument attached to this `FilterStates`.
     #' @param datalabel (`NULL` or `character(1)`)\cr
-    #'   text label value.
+    #'   text label value. Should be a name of experiment.
     #'
     initialize = function(data,
                           data_reactive = function(sid = "") NULL,

--- a/R/FilterStatesSE.R
+++ b/R/FilterStatesSE.R
@@ -24,7 +24,7 @@ SEFilterStates <- R6::R6Class( # nolint
     #'   name of the data used in the expression
     #'   specified to the function argument attached to this `FilterStates`.
     #' @param datalabel (`character(0)` or `character(1)`)\cr
-    #'   text label value.
+    #'   text label value. Should be a name of experiment
     #'
     initialize = function(data,
                           data_reactive = function(sid = "") NULL,
@@ -243,7 +243,9 @@ SEFilterStates <- R6::R6Class( # nolint
                 )
               )
               varname <- input$col_to_add
-              self$set_filter_state(filter_settings(filter_var(private$dataname, varname, arg = "select")))
+              self$set_filter_state(filter_settings(
+                filter_var(private$dataname, varname, experiment = private$datalabel, arg = "select")
+              ))
 
               logger::log_trace(
                 sprintf(
@@ -267,7 +269,9 @@ SEFilterStates <- R6::R6Class( # nolint
                 )
               )
               varname <- input$row_to_add
-              self$set_filter_state(filter_settings(filter_var(private$dataname, varname, arg = "subset")))
+              self$set_filter_state(filter_settings(
+                filter_var(private$dataname, varname, experiment = private$datalabel, arg = "subset")
+              ))
 
               logger::log_trace(
                 sprintf(

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -456,11 +456,9 @@ FilteredData <- R6::R6Class( # nolint
     #'     filter_var(dataname = "iris", varname = "Species", selected = c("setosa", "versicolor"),
     #'                keep_na = FALSE),
     #'     filter_var(dataname = "mae", varname = "years_to_birth", selected = c(30, 50),
-    #'                keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"),
-    #'     filter_var(dataname = "mae", varname = "vital_status",
-    #'                selected = "1", keep_na = FALSE, datalabel = "subjects", arg = "y"),
-    #'     filter_var(dataname = "mae", varname = "gender",
-    #'                selected = "female", keep_na = TRUE, datalabel = "subjects", arg = "y"),
+    #'                keep_na = TRUE, keep_inf = FALSE),
+    #'     filter_var(dataname = "mae", varname = "vital_status", selected = "1", keep_na = FALSE),
+    #'     filter_var(dataname = "mae", varname = "gender", selected = "female", keep_na = TRUE),
     #'     filter_var(dataname = "mae", varname = "ARRAY_TYPE",
     #'                selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset")
     #'   )

--- a/R/FilteredDatasetMAE.R
+++ b/R/FilteredDatasetMAE.R
@@ -101,8 +101,8 @@ MAEFilteredDataset <- R6::R6Class( # nolint
         })
 
         # set state on subjects
-        subject_state <- Filter(function(x) is.null(x$experiment), state)
-        private$get_filter_states()[["subjects"]]$set_filter_state(subject_state)
+        state_subjects <- Filter(function(x) is.null(x$experiment), state)
+        private$get_filter_states()[["subjects"]]$set_filter_state(state_subjects)
 
         # set state on experiments
         # determine target experiments (defined in teal_slices)
@@ -145,8 +145,8 @@ MAEFilteredDataset <- R6::R6Class( # nolint
 
         logger::log_trace("{ class(self)[1] }$remove_filter_state removing filter(s), dataname: { private$dataname }")
         # remove state on subjects
-        subject_state <- Filter(function(x) is.null(x$experiment), state)
-        private$get_filter_states()[["subjects"]]$remove_filter_state(subject_state)
+        state_subjects <- Filter(function(x) is.null(x$experiment), state)
+        private$get_filter_states()[["subjects"]]$remove_filter_state(state_subjects)
 
         # remove state on experiments
         # determine target experiments (defined in teal_slices)

--- a/R/FilteredDatasetMAE.R
+++ b/R/FilteredDatasetMAE.R
@@ -100,23 +100,28 @@ MAEFilteredDataset <- R6::R6Class( # nolint
           checkmate::assert_true(x$dataname == private$dataname, .var.name = "dataname matches private$dataname")
         })
 
-        # determine target datalabels (defined in teal_slices)
-        datalabels <- slices_field(state, "datalabel")
-        slot_names <- names(private$get_filter_states())
-        excluded_filters <- setdiff(datalabels, slot_names)
+        # set state on subjects
+        subject_state <- Filter(function(x) is.null(x$experiment), state)
+        private$get_filter_states()[["subjects"]]$set_filter_state(subject_state)
+
+        # set state on experiments
+        # determine target experiments (defined in teal_slices)
+        experiments <- slices_field(state, "experiment")
+        available_experiments <- setdiff(names(private$get_filter_states()), "subjects")
+        excluded_filters <- setdiff(experiments, available_experiments)
         if (length(excluded_filters)) {
           stop(sprintf(
-            "%s doesn't contain elements soecified in 'datalabel': %s\n'datalabel' should be a subset of: %s",
+            "%s doesn't contain elements specified in 'experiment': %s\n'experiment' should be a subset of: %s",
             private$dataname,
-            paste(excluded_filters, collapse = ", "),
-            paste(slot_names, collapse = ", ")
+            toString(excluded_filters),
+            toString(available_experiments)
           ))
         }
 
-        # set states on state_lists with corresponding datalabels
-        lapply(datalabels, function(datalabel) {
-          slices <- Filter(function(x) identical(x$datalabel, datalabel), state)
-          private$get_filter_states()[[datalabel]]$set_filter_state(slices)
+        # set states on state_lists with corresponding experiments
+        lapply(experiments, function(experiment) {
+          slices <- Filter(function(x) identical(x$experiment, experiment), state)
+          private$get_filter_states()[[experiment]]$set_filter_state(slices)
         })
 
         logger::log_trace("{ class(self)[1] }$set_filter_state initialized, dataname: { private$dataname }")
@@ -139,14 +144,29 @@ MAEFilteredDataset <- R6::R6Class( # nolint
         checkmate::assert_class(state, "teal_slices")
 
         logger::log_trace("{ class(self)[1] }$remove_filter_state removing filter(s), dataname: { private$dataname }")
+        # remove state on subjects
+        subject_state <- Filter(function(x) is.null(x$experiment), state)
+        private$get_filter_states()[["subjects"]]$remove_filter_state(subject_state)
 
-        datalabels <- slices_field(state, "datalabel")
-        current_states <- shiny::isolate(self$get_filter_state())
-
-        lapply(datalabels, function(datalabel) {
-          slice <- Filter(function(x) identical(x$datalabel, datalabel), state)
-          private$get_filter_states()[[datalabel]]$remove_filter_state(slice)
+        # remove state on experiments
+        # determine target experiments (defined in teal_slices)
+        experiments <- slices_field(state, "experiment")
+        available_experiments <- setdiff(names(private$get_filter_states()), "subjects")
+        excluded_filters <- setdiff(experiments, available_experiments)
+        if (length(excluded_filters)) {
+          stop(sprintf(
+            "%s doesn't contain elements specified in 'experiment': %s\n'experiment' should be a subset of: %s",
+            private$dataname,
+            toString(excluded_filters),
+            toString(available_experiments)
+          ))
+        }
+        # remove states on state_lists with corresponding experiments
+        lapply(experiments, function(experiment) {
+          slices <- Filter(function(x) identical(x$experiment, experiment), state)
+          private$get_filter_states()[[experiment]]$remove_filter_state(slices)
         })
+
 
         logger::log_trace("{ class(self)[1] }$remove_filter_state removed filter(s), dataname: { private$dataname }")
 

--- a/R/filter_panel_api.R
+++ b/R/filter_panel_api.R
@@ -33,19 +33,19 @@
 #'   filter_var(dataname = "iris", varname = "Sepal.Length", selected = c(5.1, 6.4)),
 #'   filter_var(
 #'     dataname = "mae", varname = "years_to_birth", selected = c(30, 50),
-#'     keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects"
+#'     keep_na = TRUE, keep_inf = FALSE
 #'   ),
 #'   filter_var(
 #'     dataname = "mae", varname = "vital_status", selected = "1",
-#'     keep_na = FALSE, datalabel = "subjects"
+#'     keep_na = FALSE
 #'   ),
 #'   filter_var(
 #'     dataname = "mae", varname = "gender", selected = "female",
-#'     keep_na = TRUE, datalabel = "subjects"
+#'     keep_na = TRUE
 #'   ),
 #'   filter_var(
 #'     dataname = "mae", varname = "ARRAY_TYPE", selected = "",
-#'     keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+#'     keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
 #'   )
 #' )
 #'

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -169,7 +169,7 @@ filter_var <- function(dataname,
   checkmate::assert_flag(multiple)
   ans <- c(as.list(environment()), list(...))
   if (missing(id)) {
-    ans$id <- paste(Filter(length, ans[c("dataname", "varname", "datalabel", "arg")]), collapse = " ")
+    ans$id <- paste(Filter(length, ans[c("dataname", "varname", "experiment", "arg")]), collapse = " ")
   }
   checkmate::assert_string(ans$id, .var.name = "id")
   ans <- do.call(shiny::reactiveValues, ans)
@@ -339,13 +339,13 @@ as.teal_slices <- function(x) { # nolint
       identical(x, list()) ||
       is.atomic(x)
   }
-  make_args <- function(object, dataname, varname, datalabel, arg = NULL) {
+  make_args <- function(object, dataname, varname, experiment = NULL, arg = NULL) {
     args <- list(
       dataname = dataname,
       varname = varname
     )
-    if (!missing(datalabel)) args$datalabel <- datalabel
-    if (!missing(arg)) args$arg <- arg
+    if (!is.null(experiment)) args$experiment <- experiment
+    if (!is.null(arg)) args$arg <- arg
     if (is.list(object)) {
       args <- c(args, object)
     } else if (is.atomic(object)) {
@@ -374,7 +374,7 @@ as.teal_slices <- function(x) { # nolint
             args <- make_args(
               subsubitem,
               dataname = dataname,
-              datalabel = name_i,
+              experiment = if (name_i != "subjects") name_i,
               varname = name_ii
             )
             slices <- c(slices, list(as.teal_slice(args)))
@@ -385,7 +385,7 @@ as.teal_slices <- function(x) { # nolint
                 args <- make_args(
                   subsubsubitem,
                   dataname = dataname,
-                  datalabel = name_i,
+                  experiment = name_i,
                   arg = name_ii,
                   varname = name_iii
                 )

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -211,7 +211,7 @@ a.remove_all:hover {
   color: rgb(122, 122, 122);
 }
 
-.parent-hideable-list-group > div.hideable-list-group:not([data-label=""]):before {
+.parent-hideable-list-group > .accordion:not([data-label=""]):before {
   padding: 2px 4px;
   font-size: 90%;
   color: #c7254e;

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -92,11 +92,9 @@ fs <-
     filter_var(dataname = "iris", varname = "Species", selected = c("setosa", "versicolor"),
                keep_na = FALSE),
     filter_var(dataname = "mae", varname = "years_to_birth", selected = c(30, 50),
-               keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"),
-    filter_var(dataname = "mae", varname = "vital_status",
-               selected = "1", keep_na = FALSE, datalabel = "subjects", arg = "y"),
-    filter_var(dataname = "mae", varname = "gender",
-               selected = "female", keep_na = TRUE, datalabel = "subjects", arg = "y"),
+               keep_na = TRUE, keep_inf = FALSE),
+    filter_var(dataname = "mae", varname = "vital_status", selected = "1", keep_na = FALSE),
+    filter_var(dataname = "mae", varname = "gender", selected = "female", keep_na = TRUE),
     filter_var(dataname = "mae", varname = "ARRAY_TYPE",
                selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset")
   )
@@ -613,11 +611,9 @@ fs <-
     filter_var(dataname = "iris", varname = "Species", selected = c("setosa", "versicolor"),
                keep_na = FALSE),
     filter_var(dataname = "mae", varname = "years_to_birth", selected = c(30, 50),
-               keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"),
-    filter_var(dataname = "mae", varname = "vital_status",
-               selected = "1", keep_na = FALSE, datalabel = "subjects", arg = "y"),
-    filter_var(dataname = "mae", varname = "gender",
-               selected = "female", keep_na = TRUE, datalabel = "subjects", arg = "y"),
+               keep_na = TRUE, keep_inf = FALSE),
+    filter_var(dataname = "mae", varname = "vital_status", selected = "1", keep_na = FALSE),
+    filter_var(dataname = "mae", varname = "gender", selected = "female", keep_na = TRUE),
     filter_var(dataname = "mae", varname = "ARRAY_TYPE",
                selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset")
   )

--- a/man/MAEFilterStates.Rd
+++ b/man/MAEFilterStates.Rd
@@ -14,7 +14,6 @@ Handles filter states in a \code{MultiAssayExperiment}
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-MAEFilterStates-new}{\code{MAEFilterStates$new()}}
-\item \href{#method-MAEFilterStates-ui_add}{\code{MAEFilterStates$ui_add()}}
 \item \href{#method-MAEFilterStates-clone}{\code{MAEFilterStates$clone()}}
 }
 }
@@ -31,6 +30,7 @@ Handles filter states in a \code{MultiAssayExperiment}
 <li><span class="pkg-link" data-pkg="teal.slice" data-topic="FilterStates" data-id="srv_active"><a href='../../teal.slice/html/FilterStates.html#method-FilterStates-srv_active'><code>teal.slice::FilterStates$srv_active()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="teal.slice" data-topic="FilterStates" data-id="srv_add"><a href='../../teal.slice/html/FilterStates.html#method-FilterStates-srv_add'><code>teal.slice::FilterStates$srv_add()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="teal.slice" data-topic="FilterStates" data-id="ui_active"><a href='../../teal.slice/html/FilterStates.html#method-FilterStates-ui_active'><code>teal.slice::FilterStates$ui_active()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="teal.slice" data-topic="FilterStates" data-id="ui_add"><a href='../../teal.slice/html/FilterStates.html#method-FilterStates-ui_add'><code>teal.slice::FilterStates$ui_add()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -77,27 +77,6 @@ key columns names}
 labels of the variables used in this object}
 }
 \if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-MAEFilterStates-ui_add"></a>}}
-\if{latex}{\out{\hypertarget{method-MAEFilterStates-ui_add}{}}}
-\subsection{Method \code{ui_add()}}{
-Shiny UI module to add filter variable
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{MAEFilterStates$ui_add(id)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{id}}{(\code{character(1)})\cr
-id of shiny module}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-shiny.tag
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/MatrixFilterStates.Rd
+++ b/man/MatrixFilterStates.Rd
@@ -67,7 +67,7 @@ name of the data used in the expression
 specified to the function argument attached to this \code{FilterStates}.}
 
 \item{\code{datalabel}}{(\code{NULL} or \code{character(1)})\cr
-text label value.}
+text label value. Should be a name of experiment.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/SEFilterStates.Rd
+++ b/man/SEFilterStates.Rd
@@ -67,7 +67,7 @@ name of the data used in the expression
 specified to the function argument attached to this \code{FilterStates}.}
 
 \item{\code{datalabel}}{(\code{character(0)} or \code{character(1)})\cr
-text label value.}
+text label value. Should be a name of experiment}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/filter_state_api.Rd
+++ b/man/filter_state_api.Rd
@@ -49,19 +49,19 @@ fs <- filter_settings(
   filter_var(dataname = "iris", varname = "Sepal.Length", selected = c(5.1, 6.4)),
   filter_var(
     dataname = "mae", varname = "years_to_birth", selected = c(30, 50),
-    keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects"
+    keep_na = TRUE, keep_inf = FALSE
   ),
   filter_var(
     dataname = "mae", varname = "vital_status", selected = "1",
-    keep_na = FALSE, datalabel = "subjects"
+    keep_na = FALSE
   ),
   filter_var(
     dataname = "mae", varname = "gender", selected = "female",
-    keep_na = TRUE, datalabel = "subjects"
+    keep_na = TRUE
   ),
   filter_var(
     dataname = "mae", varname = "ARRAY_TYPE", selected = "",
-    keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+    keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
   )
 )
 

--- a/tests/testthat/test-FilterStates.R
+++ b/tests/testthat/test-FilterStates.R
@@ -83,9 +83,9 @@ fields (dataname, varname, varlabel, arg, id) differ", {
   filter_states <- FilterStates$new(data = data.frame(a = 1:10), dataname = "a")
   fs <- filter_settings(
     filter_var(dataname = "a", varname = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a", arg = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a", arg = "a", id = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a", arg = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a"),
     count_type = "none"
   )
   filter_states$set_filter_state(fs)
@@ -111,14 +111,14 @@ testthat::test_that("remove_filter_state of inexistent FilterState raiser warnin
   )
 })
 
-testthat::test_that("remove_filter_state removes FilterState objects identified by 'dataname', 'datalabel',
+testthat::test_that("remove_filter_state removes FilterState objects identified by 'dataname', 'experiment',
 'varname', 'arg' and/or 'id'", {
   filter_states <- FilterStates$new(data = data.frame(a = 1:5), dataname = "a")
   fs <- filter_settings(
     filter_var(dataname = "a", varname = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a", arg = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a", arg = "a", id = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a", arg = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a"),
     count_type = "none"
   )
   filter_states$set_filter_state(fs)
@@ -127,17 +127,17 @@ testthat::test_that("remove_filter_state removes FilterState objects identified 
   testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 3)
 
   filter_states$remove_filter_state(filter_settings(
-    filter_var(dataname = "a", varname = "a", datalabel = "a")
+    filter_var(dataname = "a", varname = "a", experiment = "a")
   ))
   testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 2)
 
   filter_states$remove_filter_state(filter_settings(
-    filter_var(dataname = "a", varname = "a", datalabel = "a", arg = "a")
+    filter_var(dataname = "a", varname = "a", experiment = "a", arg = "a")
   ))
   testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 1)
 
   filter_states$remove_filter_state(filter_settings(
-    filter_var(dataname = "a", varname = "a", datalabel = "a", arg = "a", id = "a")
+    filter_var(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a")
   ))
   testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 0)
 })
@@ -152,9 +152,9 @@ testthat::test_that("clear_filter_state empties the state_list", {
   filter_states <- FilterStates$new(data = data.frame(a = 1:5), dataname = "a")
   fs <- filter_settings(
     filter_var(dataname = "a", varname = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a", arg = "a"),
-    filter_var(dataname = "a", varname = "a", datalabel = "a", arg = "a", id = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a", arg = "a"),
+    filter_var(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a"),
     count_type = "none"
   )
   filter_states$set_filter_state(fs)
@@ -172,7 +172,7 @@ testthat::test_that("get_call returns NULL after initialization if no filter app
 testthat::test_that("get_call returns subset call with dataname and logical expressions by default", {
   fs <- FilterStates$new(data = data.frame(a = 1:10), dataname = "test", datalabel = "1")
   fs$set_filter_state(filter_settings(
-    filter_var(dataname = "test", varname = "a", datalabel = "1", selected = c(1, 9))
+    filter_var(dataname = "test", varname = "a", experiment = "1", selected = c(1, 9))
   ))
   testthat::expect_identical(
     shiny::isolate(fs$get_call()),
@@ -190,7 +190,7 @@ testthat::test_that("get_call returns custom fun call", {
   )
   fs <- test$new(data = data.frame(a = 1:10), dataname = "test", datalabel = "1")
   fs$set_filter_state(filter_settings(
-    filter_var(dataname = "test", varname = "a", datalabel = "1", selected = c(1, 9))
+    filter_var(dataname = "test", varname = "a", experiment = "1", selected = c(1, 9))
   ))
 
   testthat::expect_identical(
@@ -212,7 +212,7 @@ testthat::test_that("get_call returns subset call on custom dataname_prefixed", 
   )
   fs <- test$new(data = data.frame(a = 1:10), dataname = "test")
   fs$set_filter_state(filter_settings(
-    filter_var(dataname = "test", varname = "a", datalabel = "1", selected = c(1, 9))
+    filter_var(dataname = "test", varname = "a", experiment = "1", selected = c(1, 9))
   ))
 
   testthat::expect_identical(
@@ -231,7 +231,7 @@ testthat::test_that("get_call returns subset with varnames prefixed depending on
   )
   fs <- test$new(data = data.frame(a = 1:10), dataname = "test")
   fs$set_filter_state(filter_settings(
-    filter_var(dataname = "test", varname = "a", datalabel = "1", selected = c(1, 9))
+    filter_var(dataname = "test", varname = "a", experiment = "1", selected = c(1, 9))
   ))
 
   testthat::expect_identical(
@@ -243,7 +243,7 @@ testthat::test_that("get_call returns subset with varnames prefixed depending on
 testthat::test_that("get_call returns subset with multiple filter expressions combined by '&' operator", {
   fs <- FilterStates$new(data = data.frame(a = 1:10, b = 1:10, c = 1:10), dataname = "test")
   fs$set_filter_state(filter_settings(
-    filter_var(dataname = "test", varname = "a", datalabel = "1", selected = c(1, 9)),
+    filter_var(dataname = "test", varname = "a", experiment = "1", selected = c(1, 9)),
     filter_expr(id = "a", dataname = "test", title = "a", expr = "b > 5 | a > 5")
   ))
 

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -431,20 +431,11 @@ testthat::test_that("set_filter_state accepts `teal_slices` and nested list and 
     filter_var(dataname = "iris", varname = "Species", selected = c("setosa", "versicolor")),
     filter_var(dataname = "iris", varname = "Sepal.Length", selected = c(5.1, 6.4)),
     filter_var(dataname = "iris", varname = "Petal.Length"),
+    filter_var(dataname = "mae", varname = "years_to_birth", selected = c(30, 50), keep_na = TRUE, keep_inf = FALSE),
+    filter_var(dataname = "mae", varname = "vital_status", selected = "1", keep_na = FALSE),
+    filter_var(dataname = "mae", varname = "gender", selected = "female", keep_na = TRUE),
     filter_var(
-      dataname = "mae", varname = "years_to_birth", datalabel = "subjects",
-      selected = c(30, 50), keep_na = TRUE, keep_inf = FALSE
-    ),
-    filter_var(
-      dataname = "mae", varname = "vital_status", datalabel = "subjects",
-      selected = "1", keep_na = FALSE
-    ),
-    filter_var(
-      dataname = "mae", varname = "gender", datalabel = "subjects",
-      selected = "female", keep_na = TRUE
-    ),
-    filter_var(
-      dataname = "mae", varname = "ARRAY_TYPE", datalabel = "RPPAArray", arg = "subset",
+      dataname = "mae", varname = "ARRAY_TYPE", experiment = "RPPAArray", arg = "subset",
       selected = "", keep_na = TRUE
     ),
     include_varnames = list(
@@ -788,7 +779,6 @@ testthat::test_that("active_datanames fails if returns dataname which isn't a su
   )
 })
 
-
 # srv_active ----
 testthat::test_that("srv_active - output$teal_filters_count returns (reactive) number of current filters applied", {
   filtered_data <- FilteredData$new(
@@ -880,21 +870,12 @@ testthat::test_that("get_filter_count properly tallies active filter states for 
     )
   )
   fs <- filter_settings(
-    filter_var(
-      dataname = "mae", varname = "years_to_birth",
-      selected = c(30, 50), keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var(
-      dataname = "mae", varname = "vital_status",
-      selected = "1", keep_na = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var(
-      dataname = "mae", varname = "gender",
-      selected = "female", keep_na = TRUE, datalabel = "subjects", arg = "y"
-    ),
+    filter_var(dataname = "mae", varname = "years_to_birth", selected = c(30, 50), keep_na = TRUE, keep_inf = FALSE),
+    filter_var(dataname = "mae", varname = "vital_status", selected = "1", keep_na = FALSE),
+    filter_var(dataname = "mae", varname = "gender", selected = "female", keep_na = TRUE),
     filter_var(
       dataname = "mae", varname = "ARRAY_TYPE",
-      selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+      selected = "", keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
     )
   )
   shiny::isolate(testthat::expect_equal(datasets$get_filter_count(), 0L))

--- a/tests/testthat/test-MAEFilterStates.R
+++ b/tests/testthat/test-MAEFilterStates.R
@@ -31,8 +31,7 @@ testthat::test_that("get_call returns subsetByColData call with varnames prefixe
   filter_states$set_filter_state(
     filter_settings(
       filter_var(
-        dataname = "miniacc", varname = "years_to_birth", selected = c(18, 60),
-        keep_na = FALSE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
+        dataname = "miniacc", varname = "years_to_birth", selected = c(18, 60), keep_na = FALSE, keep_inf = FALSE
       )
     )
   )
@@ -40,8 +39,9 @@ testthat::test_that("get_call returns subsetByColData call with varnames prefixe
   testthat::expect_equal(
     shiny::isolate(filter_states$get_call()),
     quote(
-      miniacc <- MultiAssayExperiment::subsetByColData(miniacc,
-        y = miniacc$years_to_birth >= 18 & miniacc$years_to_birth <= 60
+      miniacc <- MultiAssayExperiment::subsetByColData(
+        miniacc,
+        miniacc$years_to_birth >= 18 & miniacc$years_to_birth <= 60
       )
     )
   )

--- a/tests/testthat/test-MAEFilteredDataset.R
+++ b/tests/testthat/test-MAEFilteredDataset.R
@@ -35,19 +35,13 @@ testthat::test_that("format returns properly formatted string", {
   fs <- filter_settings(
     filter_var(
       dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50),
-      keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
+      keep_na = TRUE, keep_inf = FALSE
     ),
-    filter_var(
-      dataname = "miniacc", varname = "vital_status", selected = "1",
-      keep_na = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var(
-      dataname = "miniacc", varname = "gender", selected = "female",
-      keep_na = TRUE, datalabel = "subjects", arg = "y"
-    ),
+    filter_var(dataname = "miniacc", varname = "vital_status", selected = "1", keep_na = FALSE),
+    filter_var(dataname = "miniacc", varname = "gender", selected = "female", keep_na = TRUE),
     filter_var(
       dataname = "miniacc", varname = "ARRAY_TYPE", selected = "",
-      keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+      keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
     )
   )
   filtered_dataset$set_filter_state(fs)
@@ -70,19 +64,13 @@ testthat::test_that("print returns properly formatted string", {
   fs <- filter_settings(
     filter_var(
       dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50),
-      keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
+      keep_na = TRUE, keep_inf = FALSE
     ),
-    filter_var(
-      dataname = "miniacc", varname = "vital_status", selected = "1",
-      keep_na = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var(
-      dataname = "miniacc", varname = "gender", selected = "female",
-      keep_na = TRUE, datalabel = "subjects", arg = "y"
-    ),
+    filter_var(dataname = "miniacc", varname = "vital_status", selected = "1", keep_na = FALSE),
+    filter_var(dataname = "miniacc", varname = "gender", selected = "female", keep_na = TRUE),
     filter_var(
       dataname = "miniacc", varname = "ARRAY_TYPE", selected = "",
-      keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+      keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
     )
   )
   filtered_dataset$set_filter_state(fs)
@@ -112,19 +100,13 @@ testthat::test_that("get_call returns a call with applying filter", {
   fs <- filter_settings(
     filter_var(
       dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50),
-      keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
+      keep_na = TRUE, keep_inf = FALSE
     ),
-    filter_var(
-      dataname = "miniacc", varname = "vital_status", selected = "1",
-      keep_na = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var(
-      dataname = "miniacc", varname = "gender", selected = "female",
-      keep_na = TRUE, datalabel = "subjects", arg = "y"
-    ),
+    filter_var(dataname = "miniacc", varname = "vital_status", selected = "1", keep_na = FALSE),
+    filter_var(dataname = "miniacc", varname = "gender", selected = "female", keep_na = TRUE),
     filter_var(
       dataname = "miniacc", varname = "ARRAY_TYPE", selected = "",
-      keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+      keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
     )
   )
   filtered_dataset$set_filter_state(fs)
@@ -136,7 +118,7 @@ testthat::test_that("get_call returns a call with applying filter", {
       subjects = quote(
         miniacc <- MultiAssayExperiment::subsetByColData(
           miniacc,
-          y = (is.na(miniacc$years_to_birth) | miniacc$years_to_birth >= 30 & miniacc$years_to_birth <= 50) &
+          (is.na(miniacc$years_to_birth) | miniacc$years_to_birth >= 30 & miniacc$years_to_birth <= 50) &
             miniacc$vital_status == 1L &
             (is.na(miniacc$gender) | miniacc$gender == "female")
         )
@@ -170,19 +152,13 @@ testthat::test_that("get_filter_overview_info returns overview matrix for MAEFil
   fs <- filter_settings(
     filter_var(
       dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50),
-      keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
+      keep_na = TRUE, keep_inf = FALSE
     ),
-    filter_var(
-      dataname = "miniacc", varname = "vital_status", selected = "1",
-      keep_na = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var(
-      dataname = "miniacc", varname = "gender", selected = "female",
-      keep_na = TRUE, datalabel = "subjects", arg = "y"
-    ),
+    filter_var(dataname = "miniacc", varname = "vital_status", selected = "1", keep_na = FALSE),
+    filter_var(dataname = "miniacc", varname = "gender", selected = "female", keep_na = TRUE),
     filter_var(
       dataname = "miniacc", varname = "ARRAY_TYPE", selected = "",
-      keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+      keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
     )
   )
   filtered_dataset$set_filter_state(fs)
@@ -207,19 +183,13 @@ testthat::test_that(
     fs <- filter_settings(
       filter_var(
         dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50),
-        keep_na = FALSE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
+        keep_na = FALSE, keep_inf = FALSE
       ),
-      filter_var(
-        dataname = "miniacc", varname = "vital_status", selected = "1",
-        keep_na = FALSE, datalabel = "subjects", arg = "y"
-      ),
-      filter_var(
-        dataname = "miniacc", varname = "gender", selected = "female",
-        keep_na = FALSE, datalabel = "subjects", arg = "y"
-      ),
+      filter_var(dataname = "miniacc", varname = "vital_status", selected = "1", keep_na = FALSE),
+      filter_var(dataname = "miniacc", varname = "gender", selected = "female", keep_na = FALSE),
       filter_var(
         dataname = "miniacc", varname = "ARRAY_TYPE", selected = "",
-        keep_na = FALSE, datalabel = "RPPAArray", arg = "subset"
+        keep_na = FALSE, experiment = "RPPAArray", arg = "subset"
       )
     )
     dataset$set_filter_state(state = fs)
@@ -229,7 +199,7 @@ testthat::test_that(
         subjects = quote(
           miniacc <- MultiAssayExperiment::subsetByColData( # nolint
             miniacc,
-            y = miniacc$years_to_birth >= 30 & miniacc$years_to_birth <= 50 &
+            miniacc$years_to_birth >= 30 & miniacc$years_to_birth <= 50 &
               miniacc$vital_status == 1L &
               miniacc$gender == "female"
           )
@@ -272,23 +242,20 @@ testthat::test_that(
     fs <- filter_settings(
       filter_var(
         dataname = "miniacc", varname = "years_to_birth", choices = c(14, 83), selected = c(30, 50),
-        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE,
-        datalabel = "subjects", arg = "y"
+        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE
       ),
       filter_var(
         dataname = "miniacc", varname = "vital_status", choices = c("0", "1"), multiple = TRUE, selected = "1",
-        keep_na = FALSE, keep_inf = NULL, fixed = FALSE, locked = FALSE,
-        datalabel = "subjects", arg = "y"
+        keep_na = FALSE, keep_inf = NULL, fixed = FALSE, locked = FALSE
       ),
       filter_var(
         dataname = "miniacc", varname = "gender", choices = c("female", "male"), multiple = TRUE, selected = "female",
-        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE,
-        datalabel = "subjects", arg = "y"
+        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE
       ),
       filter_var(
         dataname = "miniacc", varname = "ARRAY_TYPE", choices = c("", "protein_level"), multiple = TRUE, selected = "",
         keep_na = FALSE, keep_inf = NULL, fixed = FALSE, locked = FALSE,
-        datalabel = "RPPAArray", arg = "subset"
+        experiment = "RPPAArray", arg = "subset"
       ),
       count_type = "none",
       include_varnames = list(miniacc = colnames(SummarizedExperiment::colData(miniACC)))
@@ -307,24 +274,18 @@ testthat::test_that(
     fs <- filter_settings(
       filter_var(
         dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50),
-        keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects"
+        keep_na = TRUE, keep_inf = FALSE
       ),
-      filter_var(
-        dataname = "miniacc", varname = "vital_status", selected = "1",
-        keep_na = FALSE, datalabel = "subjects"
-      ),
-      filter_var(
-        dataname = "miniacc", varname = "gender", selected = "female",
-        keep_na = FALSE, datalabel = "subjects"
-      ),
+      filter_var(dataname = "miniacc", varname = "vital_status", selected = "1", keep_na = FALSE),
+      filter_var(dataname = "miniacc", varname = "gender", selected = "female", keep_na = FALSE),
       filter_var(
         dataname = "miniacc", varname = "ARRAY_TYPE", selected = "",
-        keep_na = FALSE, datalabel = "RPPAArray", arg = "subset"
+        keep_na = FALSE, experiment = "RPPAArray", arg = "subset"
       )
     )
     dataset$set_filter_state(state = fs)
     dataset$remove_filter_state(
-      filter_settings(filter_var(dataname = "miniacc", varname = "years_to_birth", datalabel = "subjects"))
+      filter_settings(filter_var(dataname = "miniacc", varname = "years_to_birth"))
     )
 
     testthat::expect_equal(
@@ -342,19 +303,13 @@ testthat::test_that(
     fs <- filter_settings(
       filter_var(
         dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50),
-        keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
+        keep_na = TRUE, keep_inf = FALSE
       ),
-      filter_var(
-        dataname = "miniacc", varname = "vital_status", selected = "1",
-        keep_na = FALSE, datalabel = "subjects", arg = "y"
-      ),
-      filter_var(
-        dataname = "miniacc", varname = "gender", selected = "female",
-        keep_na = FALSE, datalabel = "subjects", arg = "y"
-      ),
+      filter_var(dataname = "miniacc", varname = "vital_status", selected = "1", keep_na = FALSE),
+      filter_var(dataname = "miniacc", varname = "gender", selected = "female", keep_na = FALSE),
       filter_var(
         dataname = "miniacc", varname = "ARRAY_TYPE", selected = "",
-        keep_na = FALSE, datalabel = "RPPAArray", arg = "subset"
+        keep_na = FALSE, experiment = "RPPAArray", arg = "subset"
       )
     )
     dataset$set_filter_state(state = fs)
@@ -368,20 +323,13 @@ testthat::test_that("remove_filters button removes all filters", {
   filtered_dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
   fs <- filter_settings(
     filter_var(
-      dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50),
-      keep_na = FALSE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
+      dataname = "miniacc", varname = "years_to_birth", selected = c(30, 50), keep_na = FALSE, keep_inf = FALSE
     ),
-    filter_var(
-      dataname = "miniacc", varname = "vital_status", selected = 1,
-      keep_na = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var(
-      dataname = "miniacc", varname = "gender", selected = "female",
-      keep_na = FALSE, datalabel = "subjects", arg = "y"
-    ),
+    filter_var(dataname = "miniacc", varname = "vital_status", selected = 1, keep_na = FALSE),
+    filter_var(dataname = "miniacc", varname = "gender", selected = "female", keep_na = FALSE),
     filter_var(
       dataname = "miniacc", varname = "ARRAY_TYPE", selected = "",
-      keep_na = FALSE, datalabel = "RPPAArray", arg = "subset"
+      keep_na = FALSE, experiment = "RPPAArray", arg = "subset"
     ),
     count_type = "none"
   )

--- a/tests/testthat/test-RangeFilterState.R
+++ b/tests/testthat/test-RangeFilterState.R
@@ -231,7 +231,7 @@ testthat::test_that("get_call returns call if all selected but NA exists", {
     c(nums, NA),
     slice = filter_var(dataname = "data", varname = "var", keep_na = FALSE)
   )
-  testthat::expect_identical(
+  testthat::expect_equal(
     shiny::isolate(filter_state$get_call()),
     quote(var >= 1 & var <= 10)
   )

--- a/tests/testthat/test-filter_panel_api.R
+++ b/tests/testthat/test-filter_panel_api.R
@@ -130,13 +130,10 @@ testthat::test_that("get_filter_state returns `teal_slices` with features identi
   fs <- filter_settings(
     filter_var("iris", "Species", selected = c("setosa", "versicolor")),
     filter_var("iris", "Sepal.Length", selected = c(5.1, 6.4)),
-    filter_var("mae", "years_to_birth",
-      selected = c(30, 50),
-      keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var("mae", "vital_status", selected = "1", keep_na = FALSE, datalabel = "subjects", arg = "y"),
-    filter_var("mae", "gender", selected = "female", keep_na = TRUE, datalabel = "subjects", arg = "y"),
-    filter_var("mae", "ARRAY_TYPE", selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset")
+    filter_var("mae", "years_to_birth", selected = c(30, 50), keep_na = TRUE, keep_inf = FALSE),
+    filter_var("mae", "vital_status", selected = "1", keep_na = FALSE),
+    filter_var("mae", "gender", selected = "female", keep_na = TRUE),
+    filter_var("mae", "ARRAY_TYPE", selected = "", keep_na = TRUE, experiment = "RPPAArray", arg = "subset")
   )
   set_filter_state(datasets, filter = fs)
 
@@ -152,19 +149,19 @@ testthat::test_that("get_filter_state returns `teal_slices` with features identi
   ))
   testthat::expect_true(compare_slices(
     fs[[3]], fs_out[[3]],
-    fields = c("dataname", "varname", "selected", "keep_na", "keep_inf", "datalebel", "target")
+    fields = c("dataname", "varname", "selected", "keep_na", "keep_inf", "experiment", "target")
   ))
   testthat::expect_true(compare_slices(
     fs[[4]], fs_out[[4]],
-    fields = c("dataname", "varname", "selected", "keep_na", "datalebel", "target")
+    fields = c("dataname", "varname", "selected", "keep_na", "experiment", "target")
   ))
   testthat::expect_true(compare_slices(
     fs[[5]], fs_out[[5]],
-    fields = c("dataname", "varname", "selected", "keep_na", "datalebel", "target")
+    fields = c("dataname", "varname", "selected", "keep_na", "experiment", "target")
   ))
   testthat::expect_true(compare_slices(
     fs[[6]], fs_out[[6]],
-    fields = c("dataname", "varname", "selected", "keep_na", "datalebel", "target")
+    fields = c("dataname", "varname", "selected", "keep_na", "experiment", "target")
   ))
 })
 
@@ -180,13 +177,10 @@ testthat::test_that("remove_filter_state removes filter state specified by `teal
   fs <- filter_settings(
     filter_var("iris", "Species", selected = c("setosa", "versicolor")),
     filter_var("iris", "Sepal.Length", selected = c(5.1, 6.4)),
-    filter_var("mae", "years_to_birth",
-      selected = c(30, 50),
-      keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var("mae", "vital_status", selected = "1", keep_na = FALSE, datalabel = "subjects", arg = "y"),
-    filter_var("mae", "gender", selected = "female", keep_na = TRUE, datalabel = "subjects", arg = "y"),
-    filter_var("mae", "ARRAY_TYPE", selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset")
+    filter_var("mae", "years_to_birth", selected = c(30, 50), keep_na = TRUE, keep_inf = FALSE),
+    filter_var("mae", "vital_status", selected = "1", keep_na = FALSE),
+    filter_var("mae", "gender", selected = "female", keep_na = TRUE),
+    filter_var("mae", "ARRAY_TYPE", selected = "", keep_na = TRUE, experiment = "RPPAArray", arg = "subset")
   )
   set_filter_state(datasets, fs)
   testthat::expect_no_error(
@@ -210,13 +204,10 @@ testthat::test_that("clear_filter_states removes all filter states", {
   fs <- filter_settings(
     filter_var("iris", "Species", selected = c("setosa", "versicolor")),
     filter_var("iris", "Sepal.Length", selected = c(5.1, 6.4)),
-    filter_var("mae", "years_to_birth",
-      selected = c(30, 50),
-      keep_na = TRUE, keep_inf = FALSE, datalabel = "subjects", arg = "y"
-    ),
-    filter_var("mae", "vital_status", selected = "1", keep_na = FALSE, datalabel = "subjects", arg = "y"),
-    filter_var("mae", "gender", selected = "female", keep_na = TRUE, datalabel = "subjects", arg = "y"),
-    filter_var("mae", "ARRAY_TYPE", selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset")
+    filter_var("mae", "years_to_birth", selected = c(30, 50), keep_na = TRUE, keep_inf = FALSE),
+    filter_var("mae", "vital_status", selected = "1", keep_na = FALSE),
+    filter_var("mae", "gender", selected = "female", keep_na = TRUE),
+    filter_var("mae", "ARRAY_TYPE", selected = "", keep_na = TRUE, experiment = "RPPAArray", arg = "subset")
   )
   set_filter_state(datasets, fs)
   testthat::expect_no_error(


### PR DESCRIPTION
closes #364 

Done in this PR:
1. From now on specifying filters for MAE subjects doesn't require `datalabel = "subjects"`. Subjects filters require only `dataname` and `varname`
```r
filter_var(dataname = "MAE", varname = "gender")
# instead of 
filter_var(dataname = "MAE", varname = "gender", datalabel = "subjects")
```
2. changed `filter_var` argument name from `datalabel` to `experiment`. `datalabel` was never a formal argument to it is captured by `...` in `filter_var`, it is then handled in `MAEFilteredDataset` and `FilterStates*`. Now app developer will specify `experiment = "<mae experiment name>"` and this will be handled by relevant classes.

```r
filter_var(dataname = "MAE", experiment = "RPPAArray", arg = "subset", varname = "Protein", selected = TRUE)
# instead of
filter_var(dataname = "MAE", datalabel = "RPPAArray", arg = "subset", varname = "Genes")
```

However, in the `FilterStates` there is still `private$datalabel` field which is used to display name of the `MAE` slot in `ui_active`.

3. Found and fixed bug on `filter_panel_refactor@main` - columns choices for MAE subjects has been empty

<img src="https://github.com/insightsengineering/teal.slice/assets/6959016/ad67b8d7-b3f9-450d-8b77-4c2929397b9b" height="400px"/>

4. Brought back appereance of `active_ui` for MAE dataset where each slot is distinguished by label

| now | feature branch|
|--------|-------|
| ![image](https://github.com/insightsengineering/teal.slice/assets/6959016/0566c499-3763-4b69-8452-b5be75f90d81) | ![image](https://github.com/insightsengineering/teal.slice/assets/6959016/ec49eef5-e16a-4e39-aaef-8cd6788f0515) |


------------------
#### example app
```r
funny_module <- function (label = "Filter states", datanames = "all") {
  checkmate::assert_string(label)
  module(
    label = label,
    filters = datanames,
    ui = function(id, ...) {
      ns <- NS(id)
      div(
        h2("The following filter calls are generated:"),
        verbatimTextOutput(ns("filter_states")),
        verbatimTextOutput(ns("filter_calls")),
        actionButton(ns("reset"), "reset_to_default")
      )
    },
    server = function(input, output, session, data, filter_panel_api) {
      checkmate::assert_class(data, "tdata")
      observeEvent(input$reset, set_filter_state(filter_panel_api, default_filters))
      output$filter_states <-  renderText({
        logger::log_trace("rendering text1")
        filter_panel_api |> get_filter_state() |> format()
      })
      output$filter_calls <- renderText({
        logger::log_trace("rendering text2")
        attr(data, "code")()
      })
    }
  )
}
options(teal.log_level = "TRACE", teal.show_js_log = TRUE)
#options("teal.bs_theme" = bslib::bs_theme(version = 5))
#options(shiny.trace = TRUE)
pkgload::load_all("teal.slice")
pkgload::load_all("teal")
library(scda)
library(SummarizedExperiment)
utils::data(miniACC, package = "MultiAssayExperiment")

default_filters <- filter_settings(
  filter_expr(id = "F", title = "females", datalabel = "subjects", dataname = "MAE", expr = 'MAE$gender == "female"'),
  filter_var(dataname = "MAE", datalabel = "subjects", varname = "race"),
  filter_var(dataname = "MAE", datalabel = "RPPAArray", arg = "subset", varname = "Protein", selected = TRUE),
  filter_var(dataname = "MAE", datalabel = "RPPAArray", arg = "subset", varname = "Genes"),
  include_varnames = list(MAE = c("race", "gender", "vital_status")),
  count_type = "none"
)

MAE <- miniACC
data <- teal.data::teal_data(teal.data::dataset("MAE", MAE))

app <- init(
  data = data,
  modules = list(funny_module(), funny_module("module2")),
  filter = default_filters
)

runApp(app)
```