### PR TITLE
378 trim_lines parameter in format

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -113,14 +113,15 @@ FilterState <- R6::R6Class( # nolint
     #' Returns a formatted string representing this `FilterState` object.
     #'
     #' @param show_all `logical(1)` passed to `format.teal_slice`
+    #' @param trim_lines `logical(1)` passed to `format.teal_slice`
     #'
     #' @return `character(1)` the formatted string
     #'
-    format = function(show_all = FALSE) {
+    format = function(show_all = FALSE, trim_lines = TRUE) {
       sprintf(
         "%s:\n%s",
         class(self)[1],
-        format(self$get_state(), show_all = show_all)
+        format(self$get_state(), show_all = show_all, trim_lines = trim_lines)
       )
     },
 

--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -74,14 +74,15 @@ FilterStateExpr <- R6::R6Class( # nolint
     #' Returns a formatted string representing this `FilterStateExpr` object.
     #'
     #' @param show_all `logical(1)` passed to `format.teal_slice`
+    #' @param trim_lines `logical(1)` passed to `format.teal_slice`
     #'
     #' @return `character(1)` the formatted string
     #'
-    format = function(show_all = FALSE) {
+    format = function(show_all = FALSE, trim_lines = TRUE) {
       sprintf(
         "%s:\n%s",
         class(self)[1],
-        format(self$get_state(), show_all = show_all)
+        format(self$get_state(), show_all = show_all, trim_lines = trim_lines)
       )
     },
 

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -68,14 +68,15 @@ FilterStates <- R6::R6Class( # nolint
     #' Returns a formatted string representing this `FilterStates` object.
     #'
     #' @param show_all `logical(1)` passed to `format.teal_slices`
+    #' @param trim_lines `logical(1)` passed to `format.teal_slices`
     #'
     #' @return `character(1)` the formatted string
     #'
-    format = function(show_all = FALSE) {
+    format = function(show_all = FALSE, trim_lines = TRUE) {
       sprintf(
         "%s:\n%s",
         class(self)[1],
-        format(self$get_filter_state(), show_all = show_all)
+        format(self$get_filter_state(), show_all = show_all, trim_lines = trim_lines)
       )
     },
 

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -405,14 +405,15 @@ FilteredData <- R6::R6Class( # nolint
     #' Returns a formatted string representing this `FilteredData` object.
     #'
     #' @param show_all `logical(1)` passed to `format.teal_slice`
+    #' @param trim_lines `logical(1)` passed to `format.teal_slice`
     #'
     #' @return `character(1)` the formatted string
     #'
-    format = function(show_all = FALSE) {
+    format = function(show_all = FALSE, trim_lines = TRUE) {
       sprintf(
         "%s:\n%s",
         class(self)[1],
-        format(self$get_filter_state(), show_all = show_all)
+        format(self$get_filter_state(), show_all = show_all, trim_lines = trim_lines)
       )
     },
 

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -65,14 +65,15 @@ FilteredDataset <- R6::R6Class( # nolint
     #' Returns a formatted string representing this `FilteredDataset` object.
     #'
     #' @param show_all `logical(1)` passed to `format.teal_slice`
+    #' @param trim_lines `logical(1)` passed to `format.teal_slice`
     #'
     #' @return `character(1)` the formatted string
     #'
-    format = function(show_all = FALSE) {
+    format = function(show_all = FALSE, trim_lines = TRUE) {
       sprintf(
         "%s:\n%s",
         class(self)[1],
-        format(self$get_filter_state(), show_all = show_all)
+        format(self$get_filter_state(), show_all = show_all, trim_lines = trim_lines)
       )
     },
 

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -102,8 +102,8 @@
 #' as.teal_slice(list(dataname = "a", varname = "var"))
 #' format(x1)
 #' format(x1, show_all = TRUE, trim_lines = FALSE)
-#' print(x1, show_all = FALSE, trim_lines = FALSE)
-#' print(x1, show_all = FALSE, trim_lines = TRUE)
+#' print(x1)
+#' print(x1, show_all = TRUE, trim_lines = FALSE)
 #'
 #' @export
 teal_slice <- function(dataname,

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -100,7 +100,9 @@
 #' is.teal_slice(x1)
 #' as.list(x1)
 #' as.teal_slice(list(dataname = "a", varname = "var"))
-#' format(x1, show_all = FALSE, trim_lines = TRUE)
+#' format(x1)
+#' format(x1, show_all = TRUE, trim_lines = FALSE)
+#' print(x1, show_all = FALSE, trim_lines = FALSE)
 #' print(x1, show_all = FALSE, trim_lines = TRUE)
 #'
 #' @export

--- a/man/FilterState.Rd
+++ b/man/FilterState.Rd
@@ -113,13 +113,15 @@ self invisibly
 \subsection{Method \code{format()}}{
 Returns a formatted string representing this \code{FilterState} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilterState$format(show_all = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilterState$format(show_all = FALSE, trim_lines = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{show_all}}{\code{logical(1)} passed to \code{format.teal_slice}}
+
+\item{\code{trim_lines}}{\code{logical(1)} passed to \code{format.teal_slice}}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/FilterStateExpr.Rd
+++ b/man/FilterStateExpr.Rd
@@ -97,13 +97,15 @@ object created by \code{\link[=teal_slice]{teal_slice()}}}
 \subsection{Method \code{format()}}{
 Returns a formatted string representing this \code{FilterStateExpr} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilterStateExpr$format(show_all = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilterStateExpr$format(show_all = FALSE, trim_lines = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{show_all}}{\code{logical(1)} passed to \code{format.teal_slice}}
+
+\item{\code{trim_lines}}{\code{logical(1)} passed to \code{format.teal_slice}}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/FilterStates.Rd
+++ b/man/FilterStates.Rd
@@ -85,13 +85,15 @@ self invisibly
 \subsection{Method \code{format()}}{
 Returns a formatted string representing this \code{FilterStates} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilterStates$format(show_all = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilterStates$format(show_all = FALSE, trim_lines = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{show_all}}{\code{logical(1)} passed to \code{format.teal_slices}}
+
+\item{\code{trim_lines}}{\code{logical(1)} passed to \code{format.teal_slices}}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -536,13 +536,15 @@ A \code{teal_slices} object.
 \subsection{Method \code{format()}}{
 Returns a formatted string representing this \code{FilteredData} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredData$format(show_all = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilteredData$format(show_all = FALSE, trim_lines = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{show_all}}{\code{logical(1)} passed to \code{format.teal_slice}}
+
+\item{\code{trim_lines}}{\code{logical(1)} passed to \code{format.teal_slice}}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/FilteredDataset.Rd
+++ b/man/FilteredDataset.Rd
@@ -78,13 +78,15 @@ should be atomic and length one.}
 \subsection{Method \code{format()}}{
 Returns a formatted string representing this \code{FilteredDataset} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$format(show_all = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$format(show_all = FALSE, trim_lines = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{show_all}}{\code{logical(1)} passed to \code{format.teal_slice}}
+
+\item{\code{trim_lines}}{\code{logical(1)} passed to \code{format.teal_slice}}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -160,8 +160,8 @@ as.list(x1)
 as.teal_slice(list(dataname = "a", varname = "var"))
 format(x1)
 format(x1, show_all = TRUE, trim_lines = FALSE)
-print(x1, show_all = FALSE, trim_lines = FALSE)
-print(x1, show_all = FALSE, trim_lines = TRUE)
+print(x1)
+print(x1, show_all = TRUE, trim_lines = FALSE)
 
 }
 \keyword{internal}

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -158,7 +158,9 @@ x2 <- teal_slice(
 is.teal_slice(x1)
 as.list(x1)
 as.teal_slice(list(dataname = "a", varname = "var"))
-format(x1, show_all = FALSE, trim_lines = TRUE)
+format(x1)
+format(x1, show_all = TRUE, trim_lines = FALSE)
+print(x1, show_all = FALSE, trim_lines = FALSE)
 print(x1, show_all = FALSE, trim_lines = TRUE)
 
 }

--- a/tests/testthat/test-FilterState.R
+++ b/tests/testthat/test-FilterState.R
@@ -252,6 +252,24 @@ testthat::test_that("format accepts logical show_all", {
   )
 })
 
+testthat::test_that("format accepts logical trim_lines", {
+  filter_state <- FilterState$new(7, slice = teal_slice(dataname = "data", varname = "7"))
+  testthat::expect_no_error(shiny::isolate(filter_state$format(trim_lines = TRUE)))
+  testthat::expect_no_error(shiny::isolate(filter_state$format(trim_lines = FALSE)))
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(trim_lines = 1)),
+    "Assertion on 'trim_lines' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(trim_lines = 0)),
+    "Assertion on 'trim_lines' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(trim_lines = "TRUE")),
+    "Assertion on 'trim_lines' failed"
+  )
+})
+
 
 testthat::test_that("format returns a properly formatted string representation", {
   filter_state <- FilterState$new(7, slice = teal_slice(dataname = "data", varname = "7"))

--- a/tests/testthat/test-FilterStateExpr.R
+++ b/tests/testthat/test-FilterStateExpr.R
@@ -62,6 +62,52 @@ testthat::test_that("format returns a properly formatted string representation",
   )
 })
 
+testthat::test_that("format accepts logical show_all", {
+  filter_state <- FilterStateExpr$new(teal_slice(
+    id = "id",
+    title = "testtitle",
+    dataname = "x",
+    expr = "x == 'x'"
+  ))
+  testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = TRUE)))
+  testthat::expect_no_error(shiny::isolate(filter_state$format(show_all = FALSE)))
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 1)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = 0)),
+    "Assertion on 'show_all' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(show_all = "TRUE")),
+    "Assertion on 'show_all' failed"
+  )
+})
+
+testthat::test_that("format accepts logical trim_lines", {
+  filter_state <- FilterStateExpr$new(teal_slice(
+    id = "id",
+    title = "testtitle",
+    dataname = "x",
+    expr = "x == 'x'"
+  ))
+  testthat::expect_no_error(shiny::isolate(filter_state$format(trim_lines = TRUE)))
+  testthat::expect_no_error(shiny::isolate(filter_state$format(trim_lines = FALSE)))
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(trim_lines = 1)),
+    "Assertion on 'trim_lines' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(trim_lines = 0)),
+    "Assertion on 'trim_lines' failed: Must be of type 'logical flag', not 'double'"
+  )
+  testthat::expect_error(
+    shiny::isolate(filter_state$format(trim_lines = "TRUE")),
+    "Assertion on 'trim_lines' failed"
+  )
+})
+
 # print ---
 testthat::test_that("print returns a properly formatted string representation", {
   state <- FilterStateExpr$new(teal_slice(

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -493,6 +493,14 @@ testthat::test_that("get_filter_state returns `teal_slices` with features identi
     shiny::isolate(datasets$format(show_all = TRUE)),
     paste0("FilteredData:\n", format(fs_out, show_all = TRUE))
   )
+  testthat::expect_identical(
+    shiny::isolate(datasets$format(trim_lines = FALSE)),
+    paste0("FilteredData:\n", format(fs_out, trim_lines = FALSE))
+  )
+  testthat::expect_identical(
+    shiny::isolate(datasets$format(show_all = TRUE, trim_lines = FALSE)),
+    paste0("FilteredData:\n", format(fs_out, show_all = TRUE, trim_lines = FALSE))
+  )
 })
 
 # print ---
@@ -534,6 +542,10 @@ testthat::test_that("print returns properly formatted string representing `teal_
   testthat::expect_identical(
     utils::capture.output(shiny::isolate(datasets$print(show_all = TRUE))),
     c("FilteredData:", utils::capture.output(print(fs, show_all = TRUE)))
+  )
+  testthat::expect_identical(
+    utils::capture.output(shiny::isolate(datasets$print(trim_lines = FALSE))),
+    c("FilteredData:", utils::capture.output(print(fs, trim_lines = FALSE)))
   )
 })
 

--- a/tests/testthat/test-FilteredDataset.R
+++ b/tests/testthat/test-FilteredDataset.R
@@ -71,6 +71,14 @@ testthat::test_that("format returns a string representation of filters", {
     shiny::isolate(dataset$format(show_all = TRUE)),
     shiny::isolate(format(dataset, show_all = TRUE))
   )
+  testthat::expect_equal(
+    shiny::isolate(dataset$format(trim_lines = FALSE)),
+    shiny::isolate(format(dataset, trim_lines = FALSE))
+  )
+  testthat::expect_equal(
+    shiny::isolate(dataset$format(show_all = TRUE, trim_lines = FALSE)),
+    shiny::isolate(format(dataset, show_all = TRUE, trim_lines = FALSE))
+  )
 })
 
 # print ---


### PR DESCRIPTION
Closes #378 

This PR provides an ability to pass `trim_lines` parameter for `$format()` method of FilterState, FilerStates, FilteredDataset and FilteredData R6 objects.