### PR TITLE
362 change argument name from locked to anchored 

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -137,7 +137,7 @@ FilterState <- R6::R6Class( # nolint
     #' @description
     #' Sets filtering state.
     #' - `fixed` state is prevented from changing state
-    #' - `locked` state is prevented from removing state
+    #' - `anchored` state is prevented from removing state
     #'
     #' @param state a `teal_slice` object
     #'
@@ -249,12 +249,21 @@ FilterState <- R6::R6Class( # nolint
             `data-bs-toggle` = "collapse",
             href = paste0("#", ns("body")),
             # header elements
-            if (private$is_locked()) icon("lock") else NULL,
-            if (private$is_fixed()) icon("burst") else NULL,
+            if (private$is_anchored()) {
+              if (private$is_fixed()) {
+                icon("anchor-lock")
+              } else {
+                icon("anchor")
+              }
+            } else if (private$is_fixed()) {
+              icon("lock")
+            } else {
+              NULL
+            },
             tags$span(tags$strong(private$get_varname())),
             tags$span(private$get_varlabel(), class = "filter-card-varlabel")
           ),
-          if (isFALSE(private$is_locked())) {
+          if (isFALSE(private$is_anchored())) {
             actionLink(
               inputId = ns("remove"),
               label = icon("circle-xmark", lib = "font-awesome"),
@@ -482,10 +491,10 @@ FilterState <- R6::R6Class( # nolint
       shiny::isolate(isTRUE(private$teal_slice$fixed))
     },
 
-    # Check whether this filter is locked (cannot be removed).
+    # Check whether this filter is anchored (cannot be removed).
     # @return `logical(1)`
-    is_locked = function() {
-      shiny::isolate(isTRUE(private$teal_slice$locked))
+    is_anchored = function() {
+      shiny::isolate(isTRUE(private$teal_slice$anchored))
     },
 
     # Check whether this filter is capable of selecting multiple values.

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -249,16 +249,12 @@ FilterState <- R6::R6Class( # nolint
             `data-bs-toggle` = "collapse",
             href = paste0("#", ns("body")),
             # header elements
-            if (private$is_anchored()) {
-              if (private$is_fixed()) {
-                icon("anchor-lock")
-              } else {
-                icon("anchor")
-              }
-            } else if (private$is_fixed()) {
+            if (private$is_anchored() && private$is_fixed()) {
+              icon("anchor-lock")
+            } else if (private$is_anchored() && !private$is_fixed()) {
+              icon("anchor")
+            } else if (!private$is_anchored() && private$is_fixed()) {
               icon("lock")
-            } else {
-              NULL
             },
             tags$span(tags$strong(private$get_varname())),
             tags$span(private$get_varlabel(), class = "filter-card-varlabel")

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -641,7 +641,7 @@ FilterStates <- R6::R6Class( # nolint
         if (any(to_remove)) {
           new_state_list <- Filter(
             function(state) {
-              if (state$get_state()$id %in% state_id && !state$get_state()$locked) {
+              if (state$get_state()$id %in% state_id && !state$get_state()$anchored) {
                 state$destroy_observers()
                 FALSE
               } else {
@@ -666,7 +666,7 @@ FilterStates <- R6::R6Class( # nolint
     state_list_empty = function() {
       shiny::isolate({
         logger::log_trace(
-          "{ class(self)[1] }$state_list_empty removing all non-locked filters for dataname: { private$dataname }"
+          "{ class(self)[1] }$state_list_empty removing all non-anchored filters for dataname: { private$dataname }"
         )
 
         state_list <- private$state_list()

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -528,7 +528,7 @@ FilteredData <- R6::R6Class( # nolint
 
       logger::log_trace(
         paste(
-          "FilteredData$clear_filter_states removed all non-locked FilterStates,",
+          "FilteredData$clear_filter_states removed all non-anchored FilterStates,",
           "datanames: { toString(datanames) }"
         )
       )
@@ -721,9 +721,9 @@ FilteredData <- R6::R6Class( # nolint
         })
 
         observeEvent(input$remove_all_filters, {
-          logger::log_trace("FilteredData$srv_filter_panel@1 removing all non-locked filters")
+          logger::log_trace("FilteredData$srv_filter_panel@1 removing all non-anchored filters")
           self$clear_filter_states()
-          logger::log_trace("FilteredData$srv_filter_panel@1 removed all non-locked filters")
+          logger::log_trace("FilteredData$srv_filter_panel@1 removed all non-anchored filters")
         })
         logger::log_trace("FilteredData$srv_active initialized")
         NULL
@@ -1173,7 +1173,7 @@ FilteredData <- R6::R6Class( # nolint
                 value = slice$id,
                 label = slice$id,
                 checked = if (slice$id %in% active_slices_ids) "checked",
-                disabled = slice$locked ||
+                disabled = slice$anchored ||
                   get_default_slice_id(slice) %in% duplicated_slice_refs &&
                     !slice$id %in% active_slices_ids
               )

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -90,12 +90,12 @@ FilteredDataset <- R6::R6Class( # nolint
     #' Removes all active filter items applied to this dataset
     #' @return NULL
     clear_filter_states = function() {
-      logger::log_trace("Removing all non-locked filters from FilteredDataset: { deparse1(self$get_dataname()) }")
+      logger::log_trace("Removing all non-anchored filters from FilteredDataset: { deparse1(self$get_dataname()) }")
       lapply(
         private$get_filter_states(),
         function(filter_states) filter_states$clear_filter_states()
       )
-      logger::log_trace("Removed all non-locked filters from FilteredDataset: { deparse1(self$get_dataname()) }")
+      logger::log_trace("Removed all non-anchored filters from FilteredDataset: { deparse1(self$get_dataname()) }")
       NULL
     },
 
@@ -329,9 +329,9 @@ FilteredDataset <- R6::R6Class( # nolint
           })
 
           observeEvent(input$remove_filters, {
-            logger::log_trace("FilteredDataset$srv_active@1 removing all non-locked filters, dataname: { dataname }")
+            logger::log_trace("FilteredDataset$srv_active@1 removing all non-anchored filters, dataname: { dataname }")
             self$clear_filter_states()
-            logger::log_trace("FilteredDataset$srv_active@1 removed all non-locked filters, dataname: { dataname }")
+            logger::log_trace("FilteredDataset$srv_active@1 removed all non-anchored filters, dataname: { dataname }")
           })
 
           logger::log_trace("FilteredDataset$initialized, dataname: { dataname }")

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -22,7 +22,7 @@
 #' this describes a filter state that refers to an expression, which can potentially include multiple variables,
 #' managed by the `FilterStateExpr` class.
 #' This class is created when `expr` is specified.
-#' `dataname` and `locked` are retained, `fixed` is set to `TRUE`, `id` becomes mandatory, `title`
+#' `dataname` and `anchored` are retained, `fixed` is set to `TRUE`, `id` becomes mandatory, `title`
 #' remains optional, while other arguments are disregarded.
 #'
 #' A teal_slice can be passed `FilterState`/`FilterStateExpr` constructors to instantiate an object.
@@ -30,12 +30,12 @@
 #' However, once a `FilterState` is created, only the mutable features can be set with a teal_slice:
 #' `selected`, `keep_na` and `keep_inf`.
 #'
-#' Special consideration is given to two fields: `fixed` and `locked`.
+#' Special consideration is given to two fields: `fixed` and `anchored`.
 #' These are always immutable logical flags that default to `FALSE`.
 #' In a `FilterState` instantiated with `fixed = TRUE` the features
 #' `selected`, `keep_na`, `keep_inf` cannot be changed.
 #' Note that a `FilterStateExpr` is always considered to have `fixed = TRUE`.
-#' A `FilterState` instantiated with `locked = TRUE` cannot be removed.
+#' A `FilterState` instantiated with `anchored = TRUE` cannot be removed.
 #'
 #' @section Filters in `SumarizedExperiment` and `MultiAssayExperiment` objects:
 #'
@@ -66,7 +66,7 @@
 #' @param keep_na (optional `logical(1)`) flag specifying whether to keep missing values
 #' @param keep_inf (optional `logical(1)`) flag specifying whether to keep infinite values
 #' @param fixed (`logical(1)`) flag specifying whether to fix this filter state (forbid setting state)
-#' @param locked (`logical(1)`) flag specifying whether to lock this filter state (forbid removing and inactivating)
+#' @param anchored (`logical(1)`) flag specifying whether to lock this filter state (forbid removing and inactivating)
 #' @param title (optional `character(1)`) title of the filter. Ignored when `varname` is set.
 #' @param ... in `teal_slice` method these are additional arguments which can be handled by extensions
 #'  of `teal.slice` classes. In other methods these are further arguments passed to or from other methods.
@@ -93,7 +93,7 @@
 #'   keep_na = TRUE,
 #'   keep_inf = TRUE,
 #'   fixed = FALSE,
-#'   locked = FALSE,
+#'   anchored = FALSE,
 #'   multiple = TRUE,
 #'   id = "Gender",
 #'   extra_arg = "extra"
@@ -119,20 +119,20 @@ teal_slice <- function(dataname,
                        keep_na = NULL,
                        keep_inf = NULL,
                        fixed = FALSE,
-                       locked = FALSE,
+                       anchored = FALSE,
                        multiple = TRUE,
                        title = NULL,
                        ...) {
   checkmate::assert_string(dataname)
   checkmate::assert_flag(fixed)
-  checkmate::assert_flag(locked)
+  checkmate::assert_flag(anchored)
 
   formal_args <- as.list(environment())
   if (!missing(expr) && !missing(varname)) {
     stop("Must provide either `expr` or `varname`.")
   } else if (!missing(expr)) {
     fixed <- TRUE
-    ts_expr_args <- c("dataname", "id", "expr", "fixed", "locked", "title")
+    ts_expr_args <- c("dataname", "id", "expr", "fixed", "anchored", "title")
     formal_args <- formal_args[ts_expr_args]
     checkmate::assert_string(id)
     checkmate::assert_string(title)
@@ -143,7 +143,7 @@ teal_slice <- function(dataname,
   } else if (!missing(varname)) {
     ts_var_args <- c(
       "dataname", "varname", "id", "choices", "selected", "keep_na", "keep_inf",
-      "fixed", "locked", "multiple"
+      "fixed", "anchored", "multiple"
     )
     formal_args <- formal_args[ts_var_args]
     args <- c(formal_args, list(...))

--- a/R/teal_slices.R
+++ b/R/teal_slices.R
@@ -46,7 +46,7 @@
 #'   keep_na = TRUE,
 #'   selected = 2,
 #'   fixed = TRUE,
-#'   locked = FALSE,
+#'   anchored = FALSE,
 #'   extra2 = "extratwo"
 #' )
 #' filter_3 <- teal_slice(
@@ -56,7 +56,7 @@
 #'   keep_na = TRUE,
 #'   selected = 0.2,
 #'   fixed = TRUE,
-#'   locked = FALSE,
+#'   anchored = FALSE,
 #'   extra1 = "extraone",
 #'   extra2 = "extratwo"
 #' )

--- a/inst/teal_slices.yml
+++ b/inst/teal_slices.yml
@@ -12,7 +12,7 @@ schemas:
           required:
             - dataname
             - id
-            - locked
+            - anchored
           properties:
             dataname:
               type: string
@@ -32,7 +32,7 @@ schemas:
               type: ['null', boolean]
             fixed:
               type: boolean
-            locked:
+            anchored:
               type: boolean
             multiple:
               type: boolean

--- a/man/FilterState.Rd
+++ b/man/FilterState.Rd
@@ -153,7 +153,7 @@ Prints this \code{FilterState} object.
 Sets filtering state.
 \itemize{
 \item \code{fixed} state is prevented from changing state
-\item \code{locked} state is prevented from removing state
+\item \code{anchored} state is prevented from removing state
 }
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilterState$set_state(state)}\if{html}{\out{</div>}}

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -19,7 +19,7 @@ teal_slice(
   keep_na = NULL,
   keep_inf = NULL,
   fixed = FALSE,
-  locked = FALSE,
+  anchored = FALSE,
   multiple = TRUE,
   title = NULL,
   ...
@@ -61,7 +61,7 @@ Type and size depends on variable type.}
 
 \item{fixed}{(\code{logical(1)}) flag specifying whether to fix this filter state (forbid setting state)}
 
-\item{locked}{(\code{logical(1)}) flag specifying whether to lock this filter state (forbid removing and inactivating)}
+\item{anchored}{(\code{logical(1)}) flag specifying whether to lock this filter state (forbid removing and inactivating)}
 
 \item{multiple}{(optional \code{logical(1)}) flag specifying whether more than one value can be selected;
 only applicable to \code{ChoicesFilterState} and \code{LogicalFilterState}}
@@ -105,7 +105,7 @@ This class is created when \verb{varname is specified. The object retains all fi
 this describes a filter state that refers to an expression, which can potentially include multiple variables,
 managed by the \code{FilterStateExpr} class.
 This class is created when \code{expr} is specified.
-\code{dataname} and \code{locked} are retained, \code{fixed} is set to \code{TRUE}, \code{id} becomes mandatory, \code{title}
+\code{dataname} and \code{anchored} are retained, \code{fixed} is set to \code{TRUE}, \code{id} becomes mandatory, \code{title}
 remains optional, while other arguments are disregarded.
 }
 
@@ -114,12 +114,12 @@ It can also be passed to \code{FilterState$set_state} to modify the state.
 However, once a \code{FilterState} is created, only the mutable features can be set with a teal_slice:
 \code{selected}, \code{keep_na} and \code{keep_inf}.
 
-Special consideration is given to two fields: \code{fixed} and \code{locked}.
+Special consideration is given to two fields: \code{fixed} and \code{anchored}.
 These are always immutable logical flags that default to \code{FALSE}.
 In a \code{FilterState} instantiated with \code{fixed = TRUE} the features
 \code{selected}, \code{keep_na}, \code{keep_inf} cannot be changed.
 Note that a \code{FilterStateExpr} is always considered to have \code{fixed = TRUE}.
-A \code{FilterState} instantiated with \code{locked = TRUE} cannot be removed.
+A \code{FilterState} instantiated with \code{anchored = TRUE} cannot be removed.
 }
 \section{Filters in \code{SumarizedExperiment} and \code{MultiAssayExperiment} objects}{
 
@@ -149,7 +149,7 @@ x2 <- teal_slice(
   keep_na = TRUE,
   keep_inf = TRUE,
   fixed = FALSE,
-  locked = FALSE,
+  anchored = FALSE,
   multiple = TRUE,
   id = "Gender",
   extra_arg = "extra"

--- a/man/teal_slices.Rd
+++ b/man/teal_slices.Rd
@@ -90,7 +90,7 @@ filter_2 <- teal_slice(
   keep_na = TRUE,
   selected = 2,
   fixed = TRUE,
-  locked = FALSE,
+  anchored = FALSE,
   extra2 = "extratwo"
 )
 filter_3 <- teal_slice(
@@ -100,7 +100,7 @@ filter_3 <- teal_slice(
   keep_na = TRUE,
   selected = 0.2,
   fixed = TRUE,
-  locked = FALSE,
+  anchored = FALSE,
   extra1 = "extraone",
   extra2 = "extratwo"
 )

--- a/tests/testthat/test-DefaultFilteredDataset.R
+++ b/tests/testthat/test-DefaultFilteredDataset.R
@@ -39,12 +39,12 @@ testthat::test_that("set_filter_state sets `teal_slice`", {
   fs <- teal_slices(
     teal_slice(
       dataname = "iris", varname = "Sepal.Length", choices = c(4.3, 7.9), selected = c(5.1, 6.4),
-      keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE
+      keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, anchored = FALSE
     ),
     teal_slice(
       dataname = "iris", varname = "Species",
       choices = c("setosa", "versicolor", "virginica"), multiple = TRUE, selected = c("setosa", "versicolor"),
-      keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE
+      keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, anchored = FALSE
     ),
     count_type = "all",
     include_varnames = list(iris = colnames(iris))
@@ -60,12 +60,12 @@ testthat::test_that("format returns a properly formatted string representation",
   fs <- teal_slices(
     teal_slice(
       dataname = "iris", varname = "Sepal.Length", choices = c(4.3, 7.9), selected = c(5.1, 6.4),
-      keep_inf = FALSE, fixed = FALSE, locked = FALSE
+      keep_inf = FALSE, fixed = FALSE, anchored = FALSE
     ),
     teal_slice(
       dataname = "iris", varname = "Species",
       choices = c("setosa", "versicolor", "virginica"), selected = c("setosa", "versicolor"),
-      keep_na = FALSE, fixed = FALSE, locked = FALSE
+      keep_na = FALSE, fixed = FALSE, anchored = FALSE
     ),
     count_type = "all",
     include_varnames = list(iris = colnames(iris))
@@ -93,12 +93,12 @@ testthat::test_that("print returns a properly formatted string representation", 
   fs <- teal_slices(
     teal_slice(
       dataname = "iris", varname = "Sepal.Length", choices = c(4.3, 7.9), selected = c(5.1, 6.4),
-      keep_inf = FALSE, fixed = FALSE, locked = FALSE
+      keep_inf = FALSE, fixed = FALSE, anchored = FALSE
     ),
     teal_slice(
       dataname = "iris", varname = "Species",
       choices = c("setosa", "versicolor", "virginica"), selected = c("setosa", "versicolor"),
-      keep_na = FALSE, fixed = FALSE, locked = FALSE
+      keep_na = FALSE, fixed = FALSE, anchored = FALSE
     ),
     count_type = "all",
     include_varnames = list(iris = colnames(iris))

--- a/tests/testthat/test-FilterState.R
+++ b/tests/testthat/test-FilterState.R
@@ -73,10 +73,10 @@ testthat::test_that("set_state cannot set mutable fields in a fixed FilterState"
   expect_identical_slice(shiny::isolate(filter_state$get_state()), old_state)
 })
 
-testthat::test_that("set_state can set mutable fields in a locked FilterState", {
+testthat::test_that("set_state can set mutable fields in a anchored FilterState", {
   filter_state <- FilterState$new(
     x = c("a", NA_character_),
-    slice = teal_slice(dataname = "data", varname = "variable", locked = TRUE)
+    slice = teal_slice(dataname = "data", varname = "variable", anchored = TRUE)
   )
   old_state <- shiny::isolate(filter_state$get_state())
   new_state <- teal_slice(
@@ -85,7 +85,7 @@ testthat::test_that("set_state can set mutable fields in a locked FilterState", 
     selected = "a",
     keep_na = TRUE,
     keep_inf = FALSE,
-    locked = TRUE
+    anchored = TRUE
   )
   filter_state$set_state(new_state)
   expect_identical_slice(shiny::isolate(filter_state$get_state()), new_state)

--- a/tests/testthat/test-FilterStates.R
+++ b/tests/testthat/test-FilterStates.R
@@ -68,7 +68,7 @@ existing filter", {
   fs <- teal_slices(
     teal_slice(
       dataname = "test", varname = "a", choices = c(1, 5), selected = c(1, 4), keep_na = FALSE, keep_inf = FALSE,
-      fixed = FALSE, locked = FALSE, any_attribute = "a", another_attribute = "b"
+      fixed = FALSE, anchored = FALSE, any_attribute = "a", another_attribute = "b"
     ),
     count_type = "none"
   )
@@ -360,16 +360,16 @@ testthat::test_that("Adding 'var_to_add' adds another filter state", {
     teal_slices(
       teal_slice(
         dataname = "iris", varname = "Sepal.Length", choices = c(4.3, 7.9), selected = c(5.1, 6.4),
-        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE
+        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, anchored = FALSE
       ),
       teal_slice(
         dataname = "iris", varname = "Petal.Length", choices = c(1.0, 6.9), selected = c(1.0, 6.9),
-        keep_na = NULL, keep_inf = NULL, fixed = FALSE, locked = FALSE
+        keep_na = NULL, keep_inf = NULL, fixed = FALSE, anchored = FALSE
       ),
       teal_slice(
         dataname = "iris", varname = "Species", choices = c("setosa", "versicolor", "virginica"),
         multiple = TRUE, selected = c("setosa", "versicolor", "virginica"), keep_na = NULL, keep_inf = NULL,
-        fixed = FALSE, locked = FALSE
+        fixed = FALSE, anchored = FALSE
       ),
       count_type = "none"
     )

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -577,7 +577,7 @@ testthat::test_that("remove_filter_state removes states specified by `teal_slice
   )
 })
 
-testthat::test_that("remove_filter_state does not remove locked filters", {
+testthat::test_that("remove_filter_state does not remove anchored filters", {
   datasets <- teal.slice:::FilteredData$new(
     list(
       iris = list(dataset = iris),
@@ -591,11 +591,11 @@ testthat::test_that("remove_filter_state does not remove locked filters", {
     ),
     teal_slice(
       dataname = "iris", varname = "Species", selected = c("setosa", "versicolor"),
-      keep_na = FALSE, locked = TRUE
+      keep_na = FALSE, anchored = TRUE
     ),
     teal_slice(
       dataname = "iris", varname = "Sepal.Width", selected = c(2.5, 3.3),
-      keep_na = FALSE, keep_inf = FALSE, locked = TRUE
+      keep_na = FALSE, keep_inf = FALSE, anchored = TRUE
     )
   )
   datasets$set_filter_state(state = fs)
@@ -603,7 +603,7 @@ testthat::test_that("remove_filter_state does not remove locked filters", {
 
   testthat::expect_length(shiny::isolate(datasets$get_filter_state()), 2)
   testthat::expect_true(
-    shiny::isolate(teal.slice:::slices_field(datasets$get_filter_state(), "locked"))
+    shiny::isolate(teal.slice:::slices_field(datasets$get_filter_state(), "anchored"))
   )
 })
 
@@ -648,7 +648,7 @@ testthat::test_that("clear_filter_states removes filters of desired dataset only
   testthat::expect_identical(shiny::isolate(slices_field(datasets$get_filter_state(), "dataname")), "mtcars")
 })
 
-testthat::test_that("clear_filter_states does not remove locked filters", {
+testthat::test_that("clear_filter_states does not remove anchored filters", {
   datasets <- teal.slice:::FilteredData$new(
     list(
       iris = list(dataset = iris),
@@ -662,11 +662,11 @@ testthat::test_that("clear_filter_states does not remove locked filters", {
     ),
     teal_slice(
       dataname = "iris", varname = "Species", selected = c("setosa", "versicolor"),
-      keep_na = FALSE, locked = TRUE
+      keep_na = FALSE, anchored = TRUE
     ),
     teal_slice(
       dataname = "iris", varname = "Sepal.Width", selected = c(2.5, 3.3),
-      keep_na = FALSE, keep_inf = FALSE, locked = TRUE
+      keep_na = FALSE, keep_inf = FALSE, anchored = TRUE
     )
   )
   datasets$set_filter_state(state = fs)
@@ -674,7 +674,7 @@ testthat::test_that("clear_filter_states does not remove locked filters", {
 
   testthat::expect_length(shiny::isolate(datasets$get_filter_state()), 2)
   testthat::expect_true(
-    shiny::isolate(teal.slice:::slices_field(datasets$get_filter_state(), "locked"))
+    shiny::isolate(teal.slice:::slices_field(datasets$get_filter_state(), "anchored"))
   )
 })
 
@@ -912,7 +912,7 @@ test_class <- R6::R6Class(
 )
 datasets <- test_class$new(list(iris = list(dataset = iris)))
 fs <- teal_slices(
-  teal_slice(dataname = "iris", varname = "Sepal.Length", locked = TRUE),
+  teal_slice(dataname = "iris", varname = "Sepal.Length", anchored = TRUE),
   teal_slice(dataname = "iris", varname = "Sepal.Width", fixed = TRUE),
   teal_slice(dataname = "iris", varname = "Petal.Length"),
   teal_slice(dataname = "iris", varname = "Petal.Width"),
@@ -957,7 +957,7 @@ shiny::testServer(
       testthat::expect_identical(active_slices_id(), c("iris Sepal.Length", "iris Sepal.Width", "iris Species"))
     })
 
-    testthat::test_that("FilteredData$srv_available_slices deactivating all keeps locked states", {
+    testthat::test_that("FilteredData$srv_available_slices deactivating all keeps anchored states", {
       session$setInputs(available_slices_id = NULL)
       testthat::expect_identical(active_slices_id(), "iris Sepal.Length")
     })

--- a/tests/testthat/test-MAEFilteredDataset.R
+++ b/tests/testthat/test-MAEFilteredDataset.R
@@ -242,19 +242,19 @@ testthat::test_that(
     fs <- teal_slices(
       teal_slice(
         dataname = "miniacc", varname = "years_to_birth", choices = c(14, 83), selected = c(30, 50),
-        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE
+        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, anchored = FALSE
       ),
       teal_slice(
         dataname = "miniacc", varname = "vital_status", choices = c("0", "1"), multiple = TRUE, selected = "1",
-        keep_na = FALSE, keep_inf = NULL, fixed = FALSE, locked = FALSE
+        keep_na = FALSE, keep_inf = NULL, fixed = FALSE, anchored = FALSE
       ),
       teal_slice(
         dataname = "miniacc", varname = "gender", choices = c("female", "male"), multiple = TRUE, selected = "female",
-        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, locked = FALSE
+        keep_na = FALSE, keep_inf = FALSE, fixed = FALSE, anchored = FALSE
       ),
       teal_slice(
         dataname = "miniacc", varname = "ARRAY_TYPE", choices = c("", "protein_level"), multiple = TRUE, selected = "",
-        keep_na = FALSE, keep_inf = NULL, fixed = FALSE, locked = FALSE,
+        keep_na = FALSE, keep_inf = NULL, fixed = FALSE, anchored = FALSE,
         experiment = "RPPAArray", arg = "subset"
       ),
       count_type = "none",

--- a/tests/testthat/test-teal_slice.R
+++ b/tests/testthat/test-teal_slice.R
@@ -11,7 +11,7 @@ testthat::test_that("teal_slice checks arguments", {
       keep_na = NULL,
       keep_inf = NULL,
       fixed = FALSE,
-      locked = FALSE,
+      anchored = FALSE,
       id = "filter",
       extra = "extra"
     )
@@ -76,12 +76,12 @@ testthat::test_that("teal_slice checks arguments", {
   )
 
   testthat::expect_error(
-    teal_slice(dataname = "data", varname = "var", locked = NULL),
-    "Assertion on 'locked' failed"
+    teal_slice(dataname = "data", varname = "var", anchored = NULL),
+    "Assertion on 'anchored' failed"
   )
   testthat::expect_error(
-    teal_slice(dataname = "data", varname = "var", locked = "TRUE"),
-    "Assertion on 'locked' failed"
+    teal_slice(dataname = "data", varname = "var", anchored = "TRUE"),
+    "Assertion on 'anchored' failed"
   )
 
   testthat::expect_error(

--- a/tests/testthat/test-teal_slices.R
+++ b/tests/testthat/test-teal_slices.R
@@ -320,5 +320,5 @@ testthat::test_that("slices_field works", {
   testthat::expect_identical(slices_field(fs, "varname"), c("var1", "var2"))
   testthat::expect_identical(slices_field(fs, "choices"), NULL)
   testthat::expect_identical(slices_field(fs, "fixed"), FALSE)
-  testthat::expect_identical(slices_field(fs, "locked"), FALSE)
+  testthat::expect_identical(slices_field(fs, "anchored"), FALSE)
 })

--- a/vignettes/filter-panel-for-developers.Rmd
+++ b/vignettes/filter-panel-for-developers.Rmd
@@ -52,7 +52,7 @@ Each `teal_slice` object contains all the information necessary to:
    - `choices` - determines the set of values or the range that can be selected from
    - `multiple` (only for `ChoiceFilterState`) - allows multiple values to be selected 
    - `fixed` - forbids changing state of the `FilterState`
-   - `locked` - forbids removal of the `FilterState`
+   - `anchored` - forbids removal of the `FilterState`
    - `title` - displayed title of the filter card
 
 In addition, every `teal_slice` object has an `id`. 


### PR DESCRIPTION
this PR fixes https://github.com/insightsengineering/teal.slice/issues/362

1. changed argument name in teal_slice from locked to anchored. and respectivly changed related function e.g is_locked to is_achored etc.


2. also changed the appereance of the filter-card to display
  - [lock](https://fontawesome.com/icons/lock?f=classic&s=solid) fixed
  - [anchor](https://fontawesome.com/icons/anchor?f=classic&s=solid) when anchored
  - [anchor locked](https://fontawesome.com/icons/anchor-lock?f=classic&s=solid) when anchored and fixed

Code to test the changes 
```

library(teal.slice)
library(shiny)

# create a FilteredData object
datasets <- init_filtered_data(
  list(
    iris = list(dataset = iris),
    mtcars = list(dataset = mtcars)
  )
)

# setting initial state
set_filter_state(
  datasets = datasets,
  filter = teal_slices(
    teal_slice(dataname = "iris", varname = "Species", selected = "virginica", keep_na = FALSE, fixed = TRUE),
    teal_slice(dataname = "iris", varname = "Sepal.Length",anchored = TRUE, fixed = TRUE),
    teal_slice(dataname = "iris", varname = "Sepal.Width",anchored = TRUE),
    count_type = "all",
    module_add = TRUE
  )
)

app <- shinyApp(
  ui = fluidPage(
    fluidRow(
      column(
        width = 9,
        tabsetPanel(
          tabPanel(title = "iris", dataTableOutput("iris_table")),
          tabPanel(title = "mtcars", dataTableOutput("mtcars_table"))
        )
      ),
      # ui for the filter panel
      column(width = 3, datasets$ui_filter_panel("filter_panel"))
    )
  ),
  server = function(input, output, session) {
    # this is the shiny server function for the filter panel and the datasets
    # object can now be used inside the application
    datasets$srv_filter_panel("filter_panel")
    
    # get the filtered datasets and put them inside reactives for analysis
    iris_filtered_data <- reactive(datasets$get_data(dataname = "iris", filtered = TRUE))
    mtcars_filtered_data <- reactive(datasets$get_data(dataname = "mtcars", filtered = TRUE))
    
    output$iris_table <- renderDataTable(iris_filtered_data())
    output$mtcars_table <- renderDataTable(mtcars_filtered_data())
  }
)
if (interactive()) {
  runApp(app)
}
```