### PR TITLE
fix UI for anchored FilterStateExpr

### DIFF
--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -179,18 +179,21 @@ FilterStateExpr <- R6::R6Class( # nolint
             class = "filter-card-header",
             tags$div(
               class = "filter-card-title",
-              icon("lock"),
+              if (private$is_anchored()) {
+                icon("anchor-lock")
+              } else {
+                icon("lock")
+              },
               tags$span(tags$strong(private$teal_slice$id)),
               tags$span(private$teal_slice$title, class = "filter-card-varlabel")
             ),
-            tags$div(
-              class = "filter-card-controls",
+            if (isFALSE(private$is_anchored())) {
               actionLink(
                 inputId = ns("remove"),
                 label = icon("circle-xmark", lib = "font-awesome"),
                 class = "filter-card-remove"
               )
-            ),
+            },
             tags$div(
               class = "filter-card-summary",
               private$ui_summary(ns("summary"))
@@ -206,6 +209,12 @@ FilterStateExpr <- R6::R6Class( # nolint
   private = list(
     observers = NULL, # stores observers
     teal_slice = NULL, # stores reactiveValues
+
+    # Check whether this filter is anchored (cannot be removed).
+    # @return `logical(1)`
+    is_anchored = function() {
+      shiny::isolate(isTRUE(private$teal_slice$anchored))
+    },
 
     # @description
     # Server module to display filter summary


### PR DESCRIPTION
On `main` specifying `anchored = TRUE` on filter expression doesn't have any effect (remove button is still on). Also icons are not consistent with FilterState

```r
# options(teal.log_level = "TRACE", teal.show_js_log = TRUE)
options("teal.bs_theme" = bslib::bs_theme(version = 3))
# options(shiny.trace = TRUE)
# todo: change groupCheckbox to include locked (not able to interact with)
#       change groupCheckbox to have some colors (instead of grey)
# todo: available filter should present information about selected values (for example tooltip)

library(shiny)
library(scda)
library(scda.2022)
library(teal.data)
library(teal.transform)
pkgload::load_all("teal.slice")
pkgload::load_all("teal")
library(teal.modules.general)

funny_module <- function(label = "Filter states", datanames = "all") {
  checkmate::assert_string(label)
  module(
    label = label,
    filters = datanames,
    ui = function(id, ...) {
      ns <- NS(id)
      div(
        h2("The following filter calls are generated:"),
        verbatimTextOutput(ns("filter_states")),
        verbatimTextOutput(ns("filter_calls")),
        actionButton(ns("reset"), "reset_to_default")
      )
    },
    server = function(input, output, session, data, filter_panel_api) {
      checkmate::assert_class(data, "tdata")
      observeEvent(input$reset, set_filter_state(filter_panel_api, default_filters))
      output$filter_states <- renderPrint({
        logger::log_trace("rendering text1")
        filter_panel_api %>% get_filter_state()
      })
      output$filter_calls <- renderText({
        logger::log_trace("rendering text2")
        attr(data, "code")()
      })
    }
  )
}
set.seed(1)

ADSL <- synthetic_cdisc_data("latest")$adsl
ADTTE <- synthetic_cdisc_data("latest")$adtte
ADRS <- synthetic_cdisc_data("latest")$adrs

default_filters <- teal_slices(
  teal_slice(dataname = "ADSL", varname = "AGE", anchored = TRUE),
  teal_slice(dataname = "ADSL", varname = "SEX", fixed = TRUE),
  teal_slice(dataname = "ADSL", varname = "RACE", anchored = TRUE, fixed = TRUE),
  teal_slice(dataname = "ADSL", id = "age_expr", title = "Non-empty AGE", expr = "!is.na(AGE)"),
  teal_slice(dataname = "ADSL", id = "arm_expr", title = "Non-empty ARM", expr = "!is.na(ARM)", anchored = TRUE)
)

app <- init(
  data = cdisc_data(
    cdisc_dataset("ADSL", ADSL),
    cdisc_dataset("ADTTE", ADTTE),
    cdisc_dataset("ADRS", ADRS)
  ),
  modules = modules(
    tm_data_table(
      "table",
      variables_selected = list(ADSL = c("STUDYID", "USUBJID", "SUBJID", "SITEID", "AGE", "SEX")),
      dt_args = list(caption = "ADSL Table Caption")
    ),
    modules(
      label = "tab1",
      funny_module("funny", datanames = NULL),
      funny_module("funny2", datanames = "ADTTE") # will limit datanames to ADTTE and ADSL (parent)
    )
  ),
  filter = default_filters
)

runApp(app)

```