### PR TITLE
fix id of FilterStateExpr

### DIFF
--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -331,17 +331,25 @@ trim_lines_json <- function(x) {
 #' `experiment` and `arg`, so that one can add `teal_slice` for a `varname`
 #' which exists in multiple `SummarizedExperiment`s or exists in both `colData`
 #' and `rowData` of given experiment.
+#' For such a vector `teal.slice` doesn't allow to activate more than one filters.
+#'
+#' In case of `teal_slice_expr` `id` is mandatory and must be unique.
 #' @param x (`teal_slice` or `list`)
 #' @return (`character(1)`) `id` for a `teal_slice` object.
 #' @keywords internal
 get_default_slice_id <- function(x) {
+  checkmate::assert_multi_class(x, c("teal_slice", "list"))
   shiny::isolate({
-    paste(
-      Filter(
-        length,
-        as.list(x)[c("dataname", "varname", "experiment", "arg")]
-      ),
-      collapse = " "
-    )
+    if (inherits(x, "teal_slice_expr") || is.null(x$varname)) {
+      x$id
+    } else {
+      paste(
+        Filter(
+          length,
+          as.list(x)[c("dataname", "varname", "experiment", "arg")]
+        ),
+        collapse = " "
+      )
+    }
   })
 }


### PR DESCRIPTION
bug appears when >1 FilterStateExpr are set. Function `get_default_slice_id` concatenated `c("dataname", "varname", "experiment", "arg")` from `teal_slice` object - in case of `teal_slice_expr` only `dataname` is specified.

This resulted in calling FilterStateExpr$server with the same id if they are from the same dataset

```r
library(shiny)
library(scda)
library(scda.2022)
library(teal.data)
library(teal.transform)
pkgload::load_all("teal.slice")
pkgload::load_all("teal")
library(teal.modules.general)

funny_module <- function(label = "Filter states", datanames = "all") {
  checkmate::assert_string(label)
  module(
    label = label,
    filters = datanames,
    ui = function(id, ...) {
      ns <- NS(id)
      div(
        h2("The following filter calls are generated:"),
        verbatimTextOutput(ns("filter_states")),
        verbatimTextOutput(ns("filter_calls")),
        actionButton(ns("reset"), "reset_to_default")
      )
    },
    server = function(input, output, session, data, filter_panel_api) {
      checkmate::assert_class(data, "tdata")
      observeEvent(input$reset, set_filter_state(filter_panel_api, default_filters))
      output$filter_states <- renderPrint({
        logger::log_trace("rendering text1")
        filter_panel_api %>% get_filter_state()
      })
      output$filter_calls <- renderText({
        logger::log_trace("rendering text2")
        attr(data, "code")()
      })
    }
  )
}
set.seed(1)

ADSL <- synthetic_cdisc_data("latest")$adsl
ADSL$empty <- NA
ADSL$logical1 <- FALSE
ADSL$logical <- sample(c(TRUE, FALSE), size = nrow(ADSL), replace = TRUE)
ADSL$numeric <- rnorm(nrow(ADSL))
ADSL$categorical2 <- sample(letters[1:10], size = nrow(ADSL), replace = TRUE)
ADSL$categorical <- sample(letters[1:3], size = nrow(ADSL), replace = TRUE, prob = c(.1, .3, .6))
ADSL$date <- Sys.Date() + seq_len(nrow(ADSL))
ADSL$date2 <- rep(Sys.Date() + 1:3, length.out = nrow(ADSL))
ADSL$datetime <- Sys.time() + seq_len(nrow(ADSL)) * 3600 * 12
ADSL$datetime2 <- rep(Sys.time() + 1:3 * 43200, length.out = nrow(ADSL))

ADSL$numeric[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$numeric[sample(1:nrow(ADSL), size = 10)] <- Inf
ADSL$logical[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$date[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$datetime[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$categorical2[sample(1:nrow(ADSL), size = 10)] <- NA
ADSL$categorical[sample(1:nrow(ADSL), size = 10)] <- NA

ADTTE <- synthetic_cdisc_data("latest")$adtte
ADRS <- synthetic_cdisc_data("latest")$adrs

ADTTE$numeric <- rnorm(nrow(ADTTE))
ADTTE$numeric[sample(1:nrow(ADTTE), size = 10, )] <- NA

teal_slice(dataname = "ADSL", varname = "categorical2", selected = c("a"), multiple = FALSE)

default_filters <- teal_slices(
  teal_slice(id = "AF", title = "ADULT FEMALE", dataname = "ADSL", expr = "SEX %in% 'F' & AGE >= 18L"),
  teal_slice(id = "SE", title = "Safety-Evaluable", dataname = "ADSL", expr = "SAFFL == 'Y'")
)

app <- init(
  data = cdisc_data(
    cdisc_dataset("ADSL", ADSL),
    cdisc_dataset("ADTTE", ADTTE),
    cdisc_dataset("ADRS", ADRS)
  ),
  modules = modules(
    tm_data_table(
      "table",
      variables_selected = list(ADSL = c("STUDYID", "USUBJID", "SUBJID", "SITEID", "AGE", "SEX")),
      dt_args = list(caption = "ADSL Table Caption")
    ),
    modules(
      label = "tab1",
      funny_module("funny", datanames = NULL),
      funny_module("funny2", datanames = "ADTTE") # will limit datanames to ADTTE and ADSL (parent)
    )
  ),
  filter = default_filters
)

runApp(app)
```