### PR TITLE
prevent to specify the same dataset in both, include_varnames and exc…

### DIFF
--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -251,6 +251,7 @@ FilterStates <- R6::R6Class( # nolint
     #' @return function which throws an error
     set_filter_state = function(state) {
       shiny::isolate({
+        if (private$dataname == "ADSL") browser()
         logger::log_trace("{ class(self)[1] }$set_filter_state initializing, dataname: { private$dataname }")
         checkmate::assert_class(state, "teal_slices")
         lapply(state, function(x) {

--- a/R/teal_slices.R
+++ b/R/teal_slices.R
@@ -10,7 +10,8 @@
 #'
 #' `include_varnames` and `exclude_varnames` determine which variables can have filters assigned.
 #' The former enumerates allowed variables, the latter enumerates forbidden values.
-#' Since these can be mutually exclusive in some cases, they cannot both be set in one `teal_slices` object.
+#' Since these can be mutually exclusive, they cannot both be set in one `teal_slices` object for one
+#' data set.
 #'
 #' @param ... any number of `teal_slice` objects. For `print` and `format`,
 #'  additional arguments passed to other functions.
@@ -100,6 +101,14 @@ teal_slices <- function(...,
   checkmate::assert_character(count_type, len = 1, null.ok = TRUE)
   checkmate::assert_subset(count_type, choices = c("all", "none"), empty.ok = TRUE)
   checkmate::assert_logical(allow_add)
+
+  duplicated_datasets <- intersect(names(include_varnames), names(exclude_varnames))
+  if (length(duplicated_datasets)) {
+    stop(
+      "Some datasets are specified in both, include_varnames and exclude_varnames:\n",
+      toString(duplicated_datasets)
+    )
+  }
 
   structure(
     slices,

--- a/man/teal_slices.Rd
+++ b/man/teal_slices.Rd
@@ -79,7 +79,8 @@ as well as \code{filter_panel_api} wrapper functions.
 
 \code{include_varnames} and \code{exclude_varnames} determine which variables can have filters assigned.
 The former enumerates allowed variables, the latter enumerates forbidden values.
-Since these can be mutually exclusive in some cases, they cannot both be set in one \code{teal_slices} object.
+Since these can be mutually exclusive, they cannot both be set in one \code{teal_slices} object for one
+data set.
 }
 \examples{
 filter_1 <- teal_slice(

--- a/tests/testthat/test-teal_slices.R
+++ b/tests/testthat/test-teal_slices.R
@@ -203,6 +203,15 @@ testthat::test_that("[.teal_slices preserves count_type", {
   )
 })
 
+testthat::test_that("teal_slices throws when include_varnames and exclude_varnames specified for the same dataset", {
+  testthat::expect_error(
+    teal_slices(
+      include_varnames = list(data1 = "var1"),
+      exclude_varnames = list(data1 = "var2")
+    ),
+    "Some datasets are specified in both, include_varnames and exclude_varnames"
+  )
+})
 
 testthat::test_that("c.teal_slices concatenates `teal_slices` objects", {
   shiny::reactiveConsole(TRUE)


### PR DESCRIPTION
During exploring #375 I figured out that one assert is missing - preventing to specify include_varnames and exclude_varnames for the same data set.