### PR TITLE
867 modify mapping matrix

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -152,8 +152,9 @@ FilteredData <- R6::R6Class( # nolint
       checkmate::assert_class(x, "reactive")
       private$available_teal_slices <- reactive({
         # Available filters should be limited to the ones relevant for this FilteredData.
-        allowed <- attr(self$get_filter_state(), "include_varnames")
-        forbidden <- attr(self$get_filter_state(), "exclude_varnames")
+        current_state <- isolate(self$get_filter_state())
+        allowed <- attr(current_state, "include_varnames")
+        forbidden <- attr(current_state, "exclude_varnames")
         foo <- function(slice) {
           if (slice$dataname %in% self$datanames()) {
             if (slice$fixed) {

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -155,6 +155,16 @@ FilteredData <- R6::R6Class( # nolint
       invisible(NULL)
     },
 
+    #' Get list of filter states available for this object.
+    #'
+    #' All `teal_slice` objects that have been created since the beginning of the app session
+    #' are stored in one `teal_slices` object. This returns a subset of that `teal_slices`,
+    #' describing filter states that can be set for this object.
+    #' @return `teal_slices`
+    get_available_teal_slices = function() {
+      (private$available_teal_slices)()
+    },
+
     # datasets methods ----
 
     #' @description

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -160,9 +160,9 @@ FilteredData <- R6::R6Class( # nolint
     #' All `teal_slice` objects that have been created since the beginning of the app session
     #' are stored in one `teal_slices` object. This returns a subset of that `teal_slices`,
     #' describing filter states that can be set for this object.
-    #' @return `teal_slices`
+    #' @return `reactive` that returns `teal_slices`
     get_available_teal_slices = function() {
-      (private$available_teal_slices)()
+      private$available_teal_slices
     },
 
     # datasets methods ----
@@ -1131,19 +1131,19 @@ FilteredData <- R6::R6Class( # nolint
       moduleServer(id, function(input, output, session) {
         slices_available <- self$get_available_teal_slices()
         slices_interactive <- reactive(
-          Filter(function(slice) isFALSE(slice$fixed), slices_available)
+          Filter(function(slice) isFALSE(slice$fixed), slices_available())
         )
         slices_fixed <- reactive(
-          Filter(function(slice) isTRUE(slice$fixed), slices_available)
+          Filter(function(slice) isTRUE(slice$fixed), slices_available())
         )
-        available_slices_id <- reactive(vapply(slices_available, `[[`, character(1), "id"))
+        available_slices_id <- reactive(vapply(slices_available(), `[[`, character(1), "id"))
         active_slices_id <- reactive(vapply(self$get_filter_state(), `[[`, character(1), "id"))
         duplicated_slice_references <- reactive({
           # slice refers to a particular column
-          slice_reference <- vapply(slices_available, get_default_slice_id, character(1))
+          slice_reference <- vapply(slices_available(), get_default_slice_id, character(1))
           is_duplicated_reference <- duplicated(slice_reference) | duplicated(slice_reference, fromLast = TRUE)
           is_active <- available_slices_id() %in% active_slices_id()
-          is_not_expr <- !vapply(slices_available, inherits, logical(1), "teal_slice_expr")
+          is_not_expr <- !vapply(slices_available(), inherits, logical(1), "teal_slice_expr")
           slice_reference[is_duplicated_reference & is_active & is_not_expr]
         })
 

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -1129,20 +1129,21 @@ FilteredData <- R6::R6Class( # nolint
     # the appropriate filter state id.
     srv_available_filters = function(id) {
       moduleServer(id, function(input, output, session) {
+        slices_available <- self$get_available_teal_slices()
         slices_interactive <- reactive(
-          Filter(function(slice) isFALSE(slice$fixed), private$available_teal_slices())
+          Filter(function(slice) isFALSE(slice$fixed), slices_available)
         )
         slices_fixed <- reactive(
-          Filter(function(slice) isTRUE(slice$fixed), private$available_teal_slices())
+          Filter(function(slice) isTRUE(slice$fixed), slices_available)
         )
-        available_slices_id <- reactive(vapply(private$available_teal_slices(), `[[`, character(1), "id"))
+        available_slices_id <- reactive(vapply(slices_available, `[[`, character(1), "id"))
         active_slices_id <- reactive(vapply(self$get_filter_state(), `[[`, character(1), "id"))
         duplicated_slice_references <- reactive({
           # slice refers to a particular column
-          slice_reference <- vapply(private$available_teal_slices(), get_default_slice_id, character(1))
+          slice_reference <- vapply(slices_available, get_default_slice_id, character(1))
           is_duplicated_reference <- duplicated(slice_reference) | duplicated(slice_reference, fromLast = TRUE)
           is_active <- available_slices_id() %in% active_slices_id()
-          is_not_expr <- !vapply(private$available_teal_slices(), inherits, logical(1), "teal_slice_expr")
+          is_not_expr <- !vapply(slices_available, inherits, logical(1), "teal_slice_expr")
           slice_reference[is_duplicated_reference & is_active & is_not_expr]
         })
 

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -209,8 +209,10 @@ Useful to display in \verb{Show R Code}.
 (\code{character}) keys of dataset
 Set list of external filter states available for activation.
 
-Unlike adding new filter from the column, these filters can come with some prespecified
-settings. \code{teal_slices} are wrapped in a \code{reactive} so one it can be updated from elsewhere in the app.
+Unlike adding new filter from the column, these filters can come with some prespecified settings.
+\code{teal_slices} are wrapped in a \code{reactive} so they can be updated from elsewhere in the app.
+Filters passed in \code{x} are limited to those that can be set for this \code{FilteredData},
+i.e. they have the correct \code{dataname} and \code{varname} (waived \code{teal_slice_fixed} as they do not have \code{varname}).
 List is accessible in \code{ui/srv_active} through \code{ui/srv_available_filters}.
 }
 }

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -103,6 +103,7 @@ shiny::isolate(datasets$get_filter_state())
 \item \href{#method-FilteredData-datanames}{\code{FilteredData$datanames()}}
 \item \href{#method-FilteredData-get_datalabel}{\code{FilteredData$get_datalabel()}}
 \item \href{#method-FilteredData-set_available_teal_slices}{\code{FilteredData$set_available_teal_slices()}}
+\item \href{#method-FilteredData-get_available_teal_slices}{\code{FilteredData$get_available_teal_slices()}}
 \item \href{#method-FilteredData-get_call}{\code{FilteredData$get_call()}}
 \item \href{#method-FilteredData-get_code}{\code{FilteredData$get_code()}}
 \item \href{#method-FilteredData-get_data}{\code{FilteredData$get_data()}}
@@ -231,6 +232,23 @@ should return \code{teal_slices}}
 }
 \subsection{Returns}{
 invisible \code{NULL}
+Get list of filter states available for this object.
+
+All \code{teal_slice} objects that have been created since the beginning of the app session
+are stored in one \code{teal_slices} object. This returns a subset of that \code{teal_slices},
+describing filter states that can be set for this object.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-FilteredData-get_available_teal_slices"></a>}}
+\if{latex}{\out{\hypertarget{method-FilteredData-get_available_teal_slices}{}}}
+\subsection{Method \code{get_available_teal_slices()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{FilteredData$get_available_teal_slices()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+\code{teal_slices}
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -248,7 +248,7 @@ describing filter states that can be set for this object.
 }
 
 \subsection{Returns}{
-\code{teal_slices}
+\code{reactive} that returns \code{teal_slices}
 }
 }
 \if{html}{\out{<hr>}}


### PR DESCRIPTION
Related to [this issue](https://github.com/insightsengineering/teal/issues/867).

`FilteredData` receives a new public method, `$get_available_teal_slices` that returns the contents of the private field `private$available_teal_slices`.