### PR TITLE
419 hidden drag handle

### DIFF
--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -188,7 +188,7 @@ RangeFilterState <- R6::R6Class( # nolint
           list(
             barmode = "overlay",
             xaxis = list(
-              range = private$get_choices(),
+              range = private$get_choices()* c(0.995, 1.005),
               rangeslider = list(thickness = 0),
               showticklabels = TRUE,
               ticks = "outside",


### PR DESCRIPTION
Fixes #419 

The range of the histogram is slightly expanded so that the drag line does not fall at the edge and (sometimes) disappear.