### PR TITLE
fix when no fixed or available filters

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -1215,9 +1215,9 @@ FilteredData <- R6::R6Class( # nolint
           htmltools::tagInsertChildren(
             checkbox,
             br(),
-            tags$strong("Fixed filters"),
+            if (length(non_interactive_choice_mock)) tags$strong("Fixed filters"),
             non_interactive_choice_mock,
-            tags$strong("Interactive filters"),
+            if (length(interactive_choice_mock)) tags$strong("Interactive filters"),
             interactive_choice_mock,
             .cssSelector = "div.shiny-options-group",
             after = 0


### PR DESCRIPTION
closes https://github.com/insightsengineering/teal.slice/issues/421 
Put condition on number of filters in a category.


| no fixed | no interactive |
|----------|----------------|
| <img width="364" alt="Skärmavbild 2023-08-03 kl  08 01 30" src="https://github.com/insightsengineering/teal.slice/assets/6959016/48b8c4bd-742c-4c52-82c2-7b5697fc7e0b"> | <img width="362" alt="Skärmavbild 2023-08-03 kl  08 02 52" src="https://github.com/insightsengineering/teal.slice/assets/6959016/72305801-713e-434a-807e-51fdb4db1b17"> |

