### PR TITLE
428 get call bug

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -588,14 +588,8 @@ FilterState <- R6::R6Class( # nolint
         return(filter_call)
       }
 
-      # Deal with empty selection (filter_call == FALSE).
-      if (isFALSE(filter_call) && isTRUE(private$get_keep_na())) {
-        call("is.na", varname)
-      } else if (isFALSE(filter_call) && isFALSE(private$get_keep_na())) {
-        filter_call
-
         # Deal with NAs.
-      } else if (is.null(filter_call) && isFALSE(private$get_keep_na())) {
+      if (is.null(filter_call) && isFALSE(private$get_keep_na())) {
         call("!", call("is.na", varname))
       } else if (!is.null(filter_call) && isTRUE(private$get_keep_na())) {
         call("|", call("is.na", varname), filter_call)

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -588,7 +588,6 @@ FilterState <- R6::R6Class( # nolint
         return(filter_call)
       }
 
-        # Deal with NAs.
       if (is.null(filter_call) && isFALSE(private$get_keep_na())) {
         call("!", call("is.na", varname))
       } else if (!is.null(filter_call) && isTRUE(private$get_keep_na())) {

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -206,10 +206,11 @@ ChoicesFilterState <- R6::R6Class( # nolint
         if (setequal(na.omit(private$x), selected)) {
           filter_call <- NULL
         } else {
+          fun_compare <- if (length(selected) == 1L) "==" else "%in%"
+
           if (private$data_class != "factor") {
             selected <- do.call(sprintf("as.%s", private$data_class), list(x = selected))
           }
-          fun_compare <- if (length(selected) == 1L) "==" else "%in%"
 
           filter_call <-
             if (inherits(selected, "Date")) {

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -201,7 +201,9 @@ ChoicesFilterState <- R6::R6Class( # nolint
       varname <- private$get_varname_prefixed(dataname)
       selected <- private$get_selected()
       if (length(selected) == 0) {
-        filter_call <- FALSE
+        choices <- private$get_choices()
+        fun_compare <- if (length(choices) == 1L) "==" else "%in%"
+        filter_call <- call("!", call(fun_compare, varname, make_c_call(as.character(choices))))
       } else {
         if (setequal(na.omit(private$x), selected)) {
           filter_call <- NULL

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -199,23 +199,23 @@ ChoicesFilterState <- R6::R6Class( # nolint
       }
       if (missing(dataname)) dataname <- private$get_dataname()
       varname <- private$get_varname_prefixed(dataname)
-      choices <- private$get_selected()
-      if (length(choices) == 0) {
+      selected <- private$get_selected()
+      if (length(selected) == 0) {
         filter_call <- FALSE
       } else {
-        if (setequal(na.omit(private$x), choices)) {
+        if (setequal(na.omit(private$x), selected)) {
           filter_call <- NULL
         } else {
           if (private$data_class != "factor") {
-            choices <- do.call(sprintf("as.%s", private$data_class), list(x = choices))
+            selected <- do.call(sprintf("as.%s", private$data_class), list(x = selected))
           }
-          fun_compare <- if (length(choices) == 1L) "==" else "%in%"
+          fun_compare <- if (length(selected) == 1L) "==" else "%in%"
 
           filter_call <-
-            if (inherits(choices, "Date")) {
-              call(fun_compare, varname, call("as.Date", make_c_call(as.character(choices))))
-            } else if (inherits(choices, c("POSIXct", "POSIXlt"))) {
-              class <- class(choices)[1L]
+            if (inherits(selected, "Date")) {
+              call(fun_compare, varname, call("as.Date", make_c_call(as.character(selected))))
+            } else if (inherits(selected, c("POSIXct", "POSIXlt"))) {
+              class <- class(selected)[1L]
               date_fun <- as.name(
                 switch(class,
                   "POSIXct" = "as.POSIXct",
@@ -225,11 +225,11 @@ ChoicesFilterState <- R6::R6Class( # nolint
               call(
                 fun_compare,
                 varname,
-                as.call(list(date_fun, make_c_call(as.character(choices)), tz = private$tzone))
+                as.call(list(date_fun, make_c_call(as.character(selected)), tz = private$tzone))
               )
             } else {
               # This handles numerics, characters, and factors.
-              call(fun_compare, varname, make_c_call(choices))
+              call(fun_compare, varname, make_c_call(selected))
             }
         }
       }

--- a/tests/testthat/test-ChoicesFilterState.R
+++ b/tests/testthat/test-ChoicesFilterState.R
@@ -555,7 +555,10 @@ testthat::test_that("get_call works for various combinations", {
     slice = teal_slice(dataname = "data", varname = "x")
   )
   filter_state$set_state(teal_slice(dataname = "data", varname = "x", selected = character()))
-  testthat::expect_equal(shiny::isolate(filter_state$get_call()), quote(is.na(x)))
+  testthat::expect_equal(
+    shiny::isolate(filter_state$get_call()),
+    quote(is.na(x) | !x %in% c("a", "b", "c", "d", "e", "f", "g", "h"))
+  )
 
   #### 20. NA=F | keep_na=NULL | FALSE ----
   filter_state <- ChoicesFilterState$new(
@@ -563,7 +566,10 @@ testthat::test_that("get_call works for various combinations", {
     slice = teal_slice(dataname = "data", varname = "x")
   )
   filter_state$set_state(teal_slice(dataname = "data", varname = "x", selected = character()))
-  testthat::expect_equal(shiny::isolate(filter_state$get_call()), FALSE)
+  testthat::expect_equal(
+    shiny::isolate(filter_state$get_call()),
+    quote(!x %in% c("a", "b", "c", "d", "e", "f", "g", "h"))
+  )
 
   #### 21. NA=T | keep_na=TRUE | is.na(x) ----
   filter_state <- ChoicesFilterState$new(
@@ -571,7 +577,10 @@ testthat::test_that("get_call works for various combinations", {
     slice = teal_slice(dataname = "data", varname = "x", keep_na = TRUE)
   )
   filter_state$set_state(teal_slice(dataname = "data", varname = "x", selected = character()))
-  testthat::expect_equal(shiny::isolate(filter_state$get_call()), quote(is.na(x)))
+  testthat::expect_equal(
+    shiny::isolate(filter_state$get_call()),
+    quote(is.na(x) | !x %in% c("a", "b", "c", "d", "e", "f", "g", "h"))
+  )
 
   #### 22. NA=F | keep_na=TRUE | FALSE ----
   filter_state <- ChoicesFilterState$new(
@@ -579,7 +588,10 @@ testthat::test_that("get_call works for various combinations", {
     slice = teal_slice(dataname = "data", varname = "x", keep_na = TRUE)
   )
   filter_state$set_state(teal_slice(dataname = "data", varname = "x", selected = character()))
-  testthat::expect_equal(shiny::isolate(filter_state$get_call()), FALSE)
+  testthat::expect_equal(
+    shiny::isolate(filter_state$get_call()),
+    quote(!x %in% c("a", "b", "c", "d", "e", "f", "g", "h"))
+  )
 
   #### 23. NA=T | keep_na=FALSE | FALSE ----
   filter_state <- ChoicesFilterState$new(
@@ -587,7 +599,10 @@ testthat::test_that("get_call works for various combinations", {
     slice = teal_slice(dataname = "data", varname = "x", keep_na = FALSE)
   )
   filter_state$set_state(teal_slice(dataname = "data", varname = "x", selected = character()))
-  testthat::expect_equal(shiny::isolate(filter_state$get_call()), FALSE)
+  testthat::expect_equal(
+    shiny::isolate(filter_state$get_call()),
+    quote(!is.na(x) & !x %in% c("a", "b", "c", "d", "e", "f", "g", "h"))
+  )
 
   #### 24. NA=F | keep_na=FALSE | FALSE ----
   filter_state <- ChoicesFilterState$new(
@@ -595,5 +610,8 @@ testthat::test_that("get_call works for various combinations", {
     slice = teal_slice(dataname = "data", varname = "x", keep_na = FALSE)
   )
   filter_state$set_state(teal_slice(dataname = "data", varname = "x", selected = character()))
-  testthat::expect_equal(shiny::isolate(filter_state$get_call()), FALSE)
+  testthat::expect_equal(
+    shiny::isolate(filter_state$get_call()),
+    quote(!x %in% c("a", "b", "c", "d", "e", "f", "g", "h"))
+  )
 })


### PR DESCRIPTION
Fixes #428 

Having `$get_call` return `FALSE` in some circumstances caused errors downstream. Specifically, `calls_combine_by` demands that all arguments be calls, logical vectors are not allowed.

`$get_call` would return `FALSE` when no values are selected, including NAs, meaning that no observations are to be included. This change was introduced to [prettify filtering calls in PR 402](https://github.com/insightsengineering/teal.slice/pull/402).

In this PR the call for the latter case has been modified to be explicit. For available choices of `c("a", "b", "c")`:
`!var %in% c("a", "b", "c")` with no NAs in data
`is.na(var) | !var %in% c("a", "b", "c")` with NAs present, included
`!is.na(var) & !var %in% c("a", "b", "c")` with NAs present, excluded

Admittedly, this is cumbersome and somewhat goes against the original work in #402. However, I believe this is the way to go because no-selection filter calls will be rare and this unseemly sight will sore users' eyes less than the old all-inclusive filter calls.