### PR TITLE
373 slices_restore will restore Dates and POSIXT classes

### DIFF
--- a/R/teal_slice-store.R
+++ b/R/teal_slice-store.R
@@ -52,6 +52,23 @@ slices_restore <- function(file) {
 
   tss_json <- jsonlite::fromJSON(file, simplifyDataFrame = FALSE)
 
+  tss_json$slices <-
+    lapply(tss_json$slices, function(slice) {
+      if(!is.null(slice$selected)) {
+        slice$selected <-
+          if(all(grepl('[0-9]{4}-[0-9]{2}-[0-9]{2}', slice$selected))) {
+            if(all(grepl('[0-9]{1,2}:[0-9]{2}:[0-9]{2}', slice$selected))) {
+              as.POSIXct(slice$selected)
+            } else {
+              as.Date(slice$selected)
+            }
+          } else {
+            slice$selected
+          }
+      }
+      slice
+    })
+
   tss_elements <- lapply(tss_json$slices, as.teal_slice)
 
   do.call(teal_slices, c(tss_elements, tss_json$attributes))


### PR DESCRIPTION
Closes #373 
A very small proposition on how we can guess that a character contains a Date a POSIXT time. Up to be discussed as we might want to just use jsonlite::serializeJSON and jsonlite::unserializeJSON

# The code

```{R}
x <- 
  teal_slice(
    dataname = "ADSL", 
    varname = "COUNTRY", 
    selected = as.POSIXct(c("2023-06-29 18:05:32 CEST", "2023-06-29 18:15:32 CEST")), 
    fixed = TRUE
  )
class(as.list(x)$selected)

t <- 
  teal_slice(
    dataname = "ADSL", 
    varname = "TIME", 
    selected = as.Date(c("2023-06-29", "2023-06-30")), 
    fixed = TRUE
  )
class(as.list(t)$selected)

y <- teal_slices(x, t)
slices_store(y, file = 'test1.json')

z <- slices_restore('test1.json')

class(shiny::isolate(z[[1]]$selected))
class(shiny::isolate(z[[2]]$selected))

````

# The code with results

```{R}
> x <- 
+   teal_slice(
+     dataname = "ADSL", 
+     varname = "COUNTRY", 
+     selected = as.POSIXct(c("2023-06-29 18:05:32 CEST", "2023-06-29 18:15:32 CEST")), 
+     fixed = TRUE
+   )
> class(as.list(x)$selected)
[1] "POSIXct" "POSIXt" 
> 
> t <- 
+   teal_slice(
+     dataname = "ADSL", 
+     varname = "TIME", 
+     selected = as.Date(c("2023-06-29", "2023-06-30")), 
+     fixed = TRUE
+   )
> class(as.list(t)$selected)
[1] "Date"
> 
> y <- teal_slices(x, t)
> slices_store(y, file = 'test1.json')
> 
> z <- slices_restore('test1.json')
> 
> class(shiny::isolate(z[[1]]$selected))
[1] "POSIXct" "POSIXt" 
> class(shiny::isolate(z[[2]]$selected))
[1] "Date"
```