### PR TITLE
Prevent to deselect any value in DateFilterState 429

### DIFF
--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -355,7 +355,7 @@ DateFilterState <- R6::R6Class( # nolint
               }
 
               if (is.na(end_date)) {
-                end_date <- private$get_selected()[1]
+                end_date <- private$get_selected()[2]
                 updateDateRangeInput(
                   session = session,
                   inputId = "selection",

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -343,12 +343,31 @@ DateFilterState <- R6::R6Class( # nolint
               logger::log_trace("DateFilterState$server@2 selection changed, id: { private$get_id() }")
               start_date <- input$selection[1]
               end_date <- input$selection[2]
-              if (start_date > end_date) {
-                showNotification(
-                  "Start date must not be greater than the end date. Setting back to default values.",
-                  type = "warning"
+
+              if (is.na(start_date)) {
+                start_date <- private$get_selected()[1]
+                updateDateRangeInput(
+                  session = session,
+                  inputId = "selection",
+                  start = start_date
                 )
+                showNotification("Start date must be selected. Setting back to previous value.", type = "warning")
               }
+
+              if (is.na(end_date)) {
+                end_date <- private$get_selected()[1]
+                updateDateRangeInput(
+                  session = session,
+                  inputId = "selection",
+                  end = end_date
+                )
+                showNotification("End date must be selected. Setting back to previous value.", type = "warning")
+              }
+
+              if (start_date > end_date) {
+                showNotification("Start date must not be greater than the end date. Setting back to default values.", type = "warning")
+              }
+
               private$set_selected(c(start_date, end_date))
             }
           )


### PR DESCRIPTION
this fixes: https://github.com/insightsengineering/teal.slice/issues/429

I have updated the DateFilterState and incorporated restoration features for previous selections. Each start and end date is now individually assessed for more accurate notifications.

The use of shinyWidgets::airDatepickerInput in DateTimefilterState poses a challenge, as it lacks a return value when cleared. This requires modifications to enable the observation of user actions and the reversion to the previous selection.

Demo

https://github.com/insightsengineering/teal.slice/assets/6700955/17b4e04a-2e8c-4518-a05e-522255d251ec


