### PR TITLE
Filter panel widgets should have equal height when accordion is closed

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -874,7 +874,6 @@ FilteredData <- R6::R6Class( # nolint
             )
           )
         ),
-        tags$br(),
         div(
           id = ns("filters_overview_contents"),
           div(


### PR DESCRIPTION
this fixes https://github.com/insightsengineering/teal.slice/issues/427

Demo
<img width="1440" alt="image" src="https://github.com/insightsengineering/teal.slice/assets/6700955/2ba87482-21e0-465e-954c-21c974d12334">

<img width="1440" alt="image" src="https://github.com/insightsengineering/teal.slice/assets/6700955/4f6691f0-0ebb-4684-a1d2-173d5382ebab">
