### PR TITLE
435 filter card header style

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: teal.slice
 Title: Filter Module for `teal` Applications
-Version: 0.4.0
-Date: 2023-08-11
+Version: 0.4.0.9000
+Date: 2023-08-14
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),
     person("Pawel", "Rucki", , "pawel.rucki@roche.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: teal.slice
 Title: Filter Module for `teal` Applications
-Version: 0.3.0.9033
+Version: 0.3.0.9034
 Date: 2023-08-10
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: teal.slice
 Title: Filter Module for `teal` Applications
-Version: 0.3.0.9034
-Date: 2023-08-10
+Version: 0.4.0
+Date: 2023-08-11
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),
     person("Pawel", "Rucki", , "pawel.rucki@roche.com", role = "aut"),
@@ -39,9 +39,9 @@ Imports:
     shinycssloaders,
     shinyjs,
     shinyWidgets (>= 0.6.2),
-    teal.data (>= 0.1.2.9011),
+    teal.data (>= 0.3.0),
     teal.logger (>= 0.1.1),
-    teal.widgets (>= 0.2.0)
+    teal.widgets (>= 0.4.0)
 Suggests:
     knitr,
     MultiAssayExperiment,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# teal.slice 0.4.0.9000
+
 # teal.slice 0.4.0
 
 ### New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.slice 0.3.0.9033
+# teal.slice 0.3.0.9034
 
 ### New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
-# teal.slice 0.3.0.9034
+# teal.slice 0.4.0
 
 ### New features
 
 * Filter panel API is now based on `teal_slice` and `teal_slices` objects.
-* It is now possible to specify a filter based on an arbitrary logical expression. See `expr` argument in `teal_slice`. 
+* It is now possible to specify a filter based on an arbitrary logical expression. See `expr` argument in `teal_slice`.
 * It is now possible to limit choices in a single filter card. See `choices` argument in `teal_slice`.
 * It is now possible to initialize the filter panel without the "Add filter variables" panel through `allow_add` in `teal_slices`.
 * It is now possible to set a filter that cannot be removed by the app user. See `anchored` argument in `teal_slice`.

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -283,9 +283,9 @@ FilterState <- R6::R6Class( # nolint
 
       # Filter card consists of header and body, arranged in a single column.
       # Body is hidden and is toggled by clicking on header.
-      # Header consists of title and summary, arranged in a column.
-      # Title consists of conditional icon, varname, conditional varlabel, and controls, arranged in a row.
-      # Summary consists of value and controls, arranged in a row.
+      ## Header consists of title and summary, arranged in a column.
+      ### Title consists of conditional icon, varname, conditional varlabel, and controls, arranged in a row.
+      ### Summary consists of value and controls, arranged in a row.
 
       div(
         id = id,

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -283,9 +283,9 @@ FilterState <- R6::R6Class( # nolint
 
       # Filter card consists of header and body, arranged in a single column.
       # Body is hidden and is toggled by clicking on header.
-        # Header consists of title and summary, arranged in a column.
-          # Title consists of conditional icon, varname, conditional varlabel, and controls, arranged in a row.
-          # Summary consists of value and controls, arranged in a row.
+      # Header consists of title and summary, arranged in a column.
+      # Title consists of conditional icon, varname, conditional varlabel, and controls, arranged in a row.
+      # Summary consists of value and controls, arranged in a row.
 
       div(
         id = id,

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -602,20 +602,8 @@ ChoicesFilterState <- R6::R6Class( # nolint
         ),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("check")
-            )
-          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("xmark")
-            )
-          } else {
-            NULL
+          if (private$na_count > 0) {
+            tags$span("NA", if (isTRUE(private$get_keep_na())) icon("check") else icon("xmark"))
           }
         )
       )

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -423,20 +423,8 @@ DateFilterState <- R6::R6Class( # nolint
         ),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("check")
-            )
-          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("xmark")
-            )
-          } else {
-            NULL
+          if (private$na_count > 0) {
+            tags$span("NA", if (isTRUE(private$get_keep_na())) icon("check") else icon("xmark"))
           }
         )
       )

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -534,20 +534,8 @@ DatetimeFilterState <- R6::R6Class( # nolint
         ),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("check")
-            )
-          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("xmark")
-            )
-          } else {
-            NULL
+          if (private$na_count > 0) {
+            tags$span("NA", if (isTRUE(private$get_keep_na())) icon("check") else icon("xmark"))
           }
         )
       )

--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -226,7 +226,7 @@ FilterStateExpr <- R6::R6Class( # nolint
 
     # @description
     # UI module to display filter summary
-    # @param shiny `id` parametr passed to moduleServer
+    # @param shiny `id` parameter passed to moduleServer
     #  renders text describing current state
     server_summary = function(id) {
       moduleServer(

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -392,20 +392,8 @@ LogicalFilterState <- R6::R6Class( # nolint
         ),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("check")
-            )
-          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("xmark")
-            )
-          } else {
-            NULL
+          if (private$na_count > 0) {
+            tags$span("NA", if (isTRUE(private$get_keep_na())) icon("check") else icon("xmark"))
           }
         )
       )

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -637,35 +637,11 @@ RangeFilterState <- R6::R6Class( # nolint
         tags$span(shiny::HTML(selection[1], "&ndash;", selection[2]), class = "filter-card-summary-value"),
         tags$span(
           class = "filter-card-summary-controls",
-          if (isTRUE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("check")
-            )
-          } else if (isFALSE(private$get_keep_na()) && private$na_count > 0) {
-            tags$span(
-              class = "filter-card-summary-na",
-              "NA",
-              shiny::icon("xmark")
-            )
-          } else {
-            NULL
+          if (private$na_count > 0) {
+            tags$span("NA", if (isTRUE(private$get_keep_na())) icon("check") else icon("xmark"))
           },
-          if (isTRUE(private$get_keep_inf()) && private$inf_count > 0) {
-            tags$span(
-              class = "filter-card-summary-inf",
-              "Inf",
-              shiny::icon("check")
-            )
-          } else if (isFALSE(private$get_keep_inf()) && private$inf_count > 0) {
-            tags$span(
-              class = "filter-card-summary-inf",
-              "Inf",
-              shiny::icon("xmark")
-            )
-          } else {
-            NULL
+          if (private$inf_count > 0) {
+            tags$span("Inf", if (isTRUE(private$get_keep_inf())) icon("check") else icon("xmark"))
           }
         )
       )


### PR DESCRIPTION
Fixes #435 

Filter card elements are rearranged and styling is changed.
Title controls (rewind, restore, remove) will cause varlabel to collapse with an ellipsis.
Byproduct: varname also becomes flexible and the overflow is trimmed