### PR TITLE
The RangeFilterState's x-axis tick labels are somewhat obstructed.

### DIFF
--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -192,7 +192,7 @@ RangeFilterState <- R6::R6Class( # nolint
               rangeslider = list(thickness = 0),
               showticklabels = TRUE,
               ticks = "outside",
-              ticklen = 2,
+              ticklen = 1.5,
               tickmode = "auto",
               nticks = 10
             ),


### PR DESCRIPTION
this fixes https://github.com/insightsengineering/teal.slice/issues/436


This problem doesn't occur in every system. While I managed to replicate it on a Mac, I couldn't reproduce it on my Windows computer. I'm somewhat uncertain whether this discrepancy is due to screen size or the operating system, but it appears that adjusting the` ticklen` helps resolve it. If the problem persists on other systems, we could attempt to address it by setting `ticks = "inside"` within Plotly's `plot_layout.`




