### PR TITLE
add disabling and reenabling of rewind and reset buttons

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -243,16 +243,26 @@ FilterState <- R6::R6Class( # nolint
             }
           )
 
+          # Buttons for rewind/reset are disabled upon change in history to prevent double-clicking.
+          # Re-enabling occurs after 100 ms, after they are potentially hidden when no history is present.
           private$observers$state_history <- observeEvent(
             eventExpr = private$state_history(),
             handlerExpr = {
+              shinyjs::disable(id = "back")
+              shinyjs::disable(id = "reset")
               shinyjs::delay(
                 ms = 100,
-                expr = shinyjs::toggleElement(id = "back", condition = length(private$state_history()) > 1L)
+                expr = {
+                  shinyjs::toggleElement(id = "back", condition = length(private$state_history()) > 1L)
+                  shinyjs::enable(id = "back")
+                }
               )
               shinyjs::delay(
                 ms = 100,
-                expr = shinyjs::toggleElement(id = "reset", condition = length(private$state_history()) > 1L)
+                expr = {
+                  shinyjs::toggleElement(id = "reset", condition = length(private$state_history()) > 1L)
+                  shinyjs::enable(id = "reset")
+                }
               )
             }
           )


### PR DESCRIPTION
Fixes #443 

When state history changes, the rewind and reset buttons are hidden if history only contains the current state. The hiding is delayed because otherwise the buttons disappear for a moment when history is updated. This creates the possibility of the rewind button being clicked again during that delay window.

In this PR the buttons are disabled for the duration of the delay.