### PR TITLE
Add/remove/restore custom expression

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -772,9 +772,9 @@ FilterState <- R6::R6Class( # nolint
         # changed directly by the api - then it's needed to rerender UI element
         # to show relevant values
         private$observers$keep_na_api <- observeEvent(
-          eventExpr = private$get_keep_na(),
           ignoreNULL = FALSE, # nothing selected is possible for NA
           ignoreInit = TRUE, # ignoreInit: should not matter because we set the UI with the desired initial state
+          eventExpr = private$get_keep_na(),
           handlerExpr = {
             if (!setequal(private$get_keep_na(), input$value)) {
               logger::log_trace("FilterState$keep_na_srv@1 changed reactive value, id: { private$get_id() }")

--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -158,7 +158,7 @@ FilterStateExpr <- R6::R6Class( # nolint
 
           new_observer <- list(
             destroy = function() {
-              logger::log_trace("Destroying FilterStateExpr inputs and observers; id: { private$get_id() }")
+              logger::log_trace("Destroying FilterStateExpr inputs; id: { private$get_id() }")
               # remove values from the input list
               lapply(session$ns(names(input)), .subset2(input, "impl")$.values$remove)
             }
@@ -225,6 +225,10 @@ FilterStateExpr <- R6::R6Class( # nolint
     destroy_shiny = NULL, # function is set in server
 
     append_observer = function(new_observer) {
+      checkmate::assert_list(new_observer, names = "named")
+      checkmate::assert_subset(names(new_observer), "destroy")
+      checkmate::assert_function(new_observer[["destroy"]])
+
       private$observers <- if (is.null(private$observers)) {
         list(new_observer)
       } else {

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -385,7 +385,8 @@ FilterStates <- R6::R6Class( # nolint
                 observeEvent(
                   eventExpr = fs_callback(), # when remove button is clicked in the FilterState ui
                   once = TRUE, # remove button can be called once, should be destroyed afterwards
-                  handlerExpr = private$state_list_remove(state$get_state()$id)
+                  handlerExpr = private$state_list_remove(state$get_state()$id),
+                  ignoreInit = TRUE
                 )
               })
               added_states(NULL)

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -383,10 +383,10 @@ FilterStates <- R6::R6Class( # nolint
               lapply(added_states(), function(state) {
                 fs_callback <- state$server(id = fs_to_shiny_ns(state))
                 observeEvent(
-                  eventExpr = fs_callback(), # when remove button is clicked in the FilterState ui
                   once = TRUE, # remove button can be called once, should be destroyed afterwards
-                  handlerExpr = private$state_list_remove(state$get_state()$id),
-                  ignoreInit = TRUE
+                  ignoreInit = TRUE, # ignoreInit: should not matter because we destroy the previous input set of the UI
+                  eventExpr = fs_callback(), # when remove button is clicked in the FilterState ui
+                  handlerExpr = private$state_list_remove(state$get_state()$id)
                 )
               })
               added_states(NULL)


### PR DESCRIPTION
# Pull Request

Fixes #453

### Changes description

- Uses same logic of destroying all values on input as `FilterState`
- Adds a protection so that this won't happen again in the future as `handleExpr` is not run during initialization
- `set_state()` :: Returns same value as `FilterState$set_state(state)`
- `get_id()` :: adds same function as `FilterState`

[Screencast from 2023-08-30 14-25-10.webm](https://github.com/insightsengineering/teal.slice/assets/211358/82018ef3-32cf-4b55-ba78-c9c25995ef6f)
