### PR TITLE
415 range selector colors

### DIFF
--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -212,11 +212,13 @@ RangeFilterState <- R6::R6Class( # nolint
         })
         private$plot_filtered <- reactive({
           finite_values <- Filter(is.finite, private$x_reactive())
-          list(
-            x = finite_values,
-            bingroup = 1,
-            color = I(fetch_bs_color("primary"))
-          )
+          if (length(finite_values)) {
+            list(
+              x = finite_values,
+              bingroup = 1,
+              color = I(fetch_bs_color("primary"))
+            )
+          }
         })
         invisible(self)
       })


### PR DESCRIPTION
Fixes #451 

The error resulted from adding the second histogram to the plot, which is based on the filtered data. All data was filtered out, `x_reactive` returnes `integer(0)`, which results in all bins being colored.

Here, an `if` statement is added when creating the second histogram trace, such that the trace itself is `NULL` if there are no data.