### PR TITLE
455 bug in filter card reactivity

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -320,7 +320,11 @@ FilterState <- R6::R6Class( # nolint
             div(
               class = "filter-card-controls",
               # Suppress toggling body when clicking on this div.
+              # This is for bootstrap 3 and 4.
               onclick = "event.stopPropagation()",
+              # This is for bootstrap 5.
+              `data-bs-toggle` = "collapse",
+              `data-bs-target` = NULL,
               if (isFALSE(private$is_fixed())) {
                 actionLink(
                   inputId = ns("back"),

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -303,13 +303,11 @@ FilterState <- R6::R6Class( # nolint
         include_js_files("count-bar-labels.js"),
         div(
           class = "filter-card-header",
+          `data-toggle` = "collapse",
+          `data-bs-toggle` = "collapse",
+          href = paste0("#", ns("body")),
           div(
-            # title properties
             class = "filter-card-title",
-            `data-toggle` = "collapse",
-            `data-bs-toggle` = "collapse",
-            href = paste0("#", ns("body")),
-            # title elements
             if (private$is_anchored() && private$is_fixed()) {
               icon("anchor-lock", class = "filter-card-icon")
             } else if (private$is_anchored() && !private$is_fixed()) {
@@ -351,13 +349,7 @@ FilterState <- R6::R6Class( # nolint
               }
             )
           ),
-          div(
-            class = "filter-card-summary",
-            `data-toggle` = "collapse",
-            `data-bs-toggle` = "collapse",
-            href = paste0("#", ns("body")),
-            private$ui_summary(ns("summary"))
-          )
+          div(class = "filter-card-summary", private$ui_summary(ns("summary")))
         ),
         div(
           id = ns("body"),

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -319,7 +319,8 @@ FilterState <- R6::R6Class( # nolint
             div(class = "filter-card-varlabel", private$get_varlabel()),
             div(
               class = "filter-card-controls",
-              onclick = "event.stopPropagation();", # prevents toggling body when clicking on this div
+              # Suppress toggling body when clicking on this div.
+              onclick = "event.stopPropagation()",
               if (isFALSE(private$is_fixed())) {
                 actionLink(
                   inputId = ns("back"),

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -319,6 +319,7 @@ FilterState <- R6::R6Class( # nolint
             div(class = "filter-card-varlabel", private$get_varlabel()),
             div(
               class = "filter-card-controls",
+              onclick = "event.stopPropagation();", # prevents toggling body when clicking on this div
               if (isFALSE(private$is_fixed())) {
                 actionLink(
                   inputId = ns("back"),

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -321,7 +321,7 @@ FilterState <- R6::R6Class( # nolint
               class = "filter-card-controls",
               # Suppress toggling body when clicking on this div.
               # This is for bootstrap 3 and 4.
-              onclick = "event.stopPropagation()",
+              onclick = "event.stopPropagation();",
               # This is for bootstrap 5.
               `data-bs-toggle` = "collapse",
               `data-bs-target` = NULL,

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -320,7 +320,7 @@ FilterState <- R6::R6Class( # nolint
             div(
               class = "filter-card-controls",
               # Suppress toggling body when clicking on this div.
-              # This is for bootstrap 3 and 4.
+              # This is for bootstrap 3 and 4. Causes page to scroll to top, prevented by setting href on buttons.
               onclick = "event.stopPropagation();",
               # This is for bootstrap 5.
               `data-bs-toggle` = "collapse",
@@ -332,7 +332,8 @@ FilterState <- R6::R6Class( # nolint
                   icon = icon("circle-arrow-left", lib = "font-awesome"),
                   title = "Rewind state",
                   class = "filter-card-back",
-                  style = "display: none"
+                  style = "display: none",
+                  href = "href"
                 )
               },
               if (isFALSE(private$is_fixed())) {
@@ -342,7 +343,8 @@ FilterState <- R6::R6Class( # nolint
                   icon = icon("circle-arrow-up", lib = "font-awesome"),
                   title = "Restore original state",
                   class = "filter-card-back",
-                  style = "display: none"
+                  style = "display: none",
+                  href = "href"
                 )
               },
               if (isFALSE(private$is_anchored())) {
@@ -350,7 +352,8 @@ FilterState <- R6::R6Class( # nolint
                   inputId = ns("remove"),
                   label = icon("circle-xmark", lib = "font-awesome"),
                   title = "Remove filter",
-                  class = "filter-card-remove"
+                  class = "filter-card-remove",
+                  href = "href"
                 )
               }
             )


### PR DESCRIPTION
Fixes #455 

The div containing the buttons (rewind, restore, remove), which is of class `filter_card_controls`, receives `onclick = "event.stopPropagation();"` property to suppress click registration by containing DOM elements. In order to work with bs5 it also receives `data-bs-toggle = "collapse"` and `data-bs-target = NULL` properties.

Since clicks from buttons do not propagate to the `filter_card_title` element, the body collapsing effect can be applied to the whole `filter_card_header` rather than to `filter_card_title` and `filter_card_summary` separately, removing duplicated code.