### PR TITLE
Restore primary color state when count_type is none

### DIFF
--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -212,7 +212,7 @@ RangeFilterState <- R6::R6Class( # nolint
         })
         private$plot_filtered <- reactive({
           finite_values <- Filter(is.finite, private$x_reactive())
-          if (length(finite_values) || is.null(finite_values)) {
+          if (!identical(finite_values, numeric(0))) {
             list(
               x = finite_values,
               bingroup = 1,

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -212,7 +212,7 @@ RangeFilterState <- R6::R6Class( # nolint
         })
         private$plot_filtered <- reactive({
           finite_values <- Filter(is.finite, private$x_reactive())
-          if (length(finite_values)) {
+          if (length(finite_values) || is.null(finite_values)) {
             list(
               x = finite_values,
               bingroup = 1,


### PR DESCRIPTION
Closes #459 

When the `count_type = "all"` the possible values for `finite_values` is a numeric vector which can also have numeric(0) which is the case when no data is available.
But when `count_type = "none"` the `finite_values` is NULL and we should change the color to primary anyway.