### PR TITLE
add single onclick event to prevent default behavior which cause app to refresh

### DIFF
--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -321,7 +321,7 @@ FilterState <- R6::R6Class( # nolint
               class = "filter-card-controls",
               # Suppress toggling body when clicking on this div.
               # This is for bootstrap 3 and 4. Causes page to scroll to top, prevented by setting href on buttons.
-              onclick = "event.stopPropagation();",
+              onclick = "event.stopPropagation();event.preventDefault();",
               # This is for bootstrap 5.
               `data-bs-toggle` = "collapse",
               `data-bs-target` = NULL,
@@ -332,8 +332,7 @@ FilterState <- R6::R6Class( # nolint
                   icon = icon("circle-arrow-left", lib = "font-awesome"),
                   title = "Rewind state",
                   class = "filter-card-back",
-                  style = "display: none",
-                  href = "href"
+                  style = "display: none"
                 )
               },
               if (isFALSE(private$is_fixed())) {
@@ -343,8 +342,7 @@ FilterState <- R6::R6Class( # nolint
                   icon = icon("circle-arrow-up", lib = "font-awesome"),
                   title = "Restore original state",
                   class = "filter-card-back",
-                  style = "display: none",
-                  href = "href"
+                  style = "display: none"
                 )
               },
               if (isFALSE(private$is_anchored())) {
@@ -352,8 +350,7 @@ FilterState <- R6::R6Class( # nolint
                   inputId = ns("remove"),
                   label = icon("circle-xmark", lib = "font-awesome"),
                   title = "Remove filter",
-                  class = "filter-card-remove",
-                  href = "href"
+                  class = "filter-card-remove"
                 )
               }
             )


### PR DESCRIPTION
Fixes insightsengineering/coredev-tasks#473

- Follow-up on #462

### Changes description

- Remove `href` that was causing an issue on deployed apps
- Single use of `event.preventDefault()` chained after `event.stopPropagation()`
  - first will prevent any navigation action by the browser (event is still caught by Shiny)
  - second will prevent the event from bubbling to parent elements _(that is, parents won't trigger the onclick event)_