### PR TITLE
#467 slices_restore restores factors

### DIFF
--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -74,6 +74,7 @@
 #' @param show_all (`logical(1)`) indicating whether to show all fields. If set to `FALSE`,
 #'  only non-NULL elements will be printed.
 #' @param trim_lines (`logical(1)`) indicating whether to trim lines when printing.
+#' @param add_levels (`logical(1)`) whether to add level values if `selected` or `choices` is a `factor`.
 #'
 #' @return A `teal.slice` object. Depending on whether `varname` or `expr` was specified, the resulting
 #' `teal_slice` also receives class `teal_slice_var` or `teal_slice_expr`, respectively.
@@ -210,14 +211,14 @@ as.list.teal_slice <- function(x, ...) {
 #' @export
 #' @keywords internal
 #'
-format.teal_slice <- function(x, show_all = FALSE, trim_lines = TRUE, ...) {
+format.teal_slice <- function(x, show_all = FALSE, trim_lines = TRUE, add_levels = FALSE, ...) {
   checkmate::assert_flag(show_all)
   checkmate::assert_flag(trim_lines)
 
   x_list <- as.list(x)
   if (!show_all) x_list <- Filter(Negate(is.null), x_list)
 
-  jsonify(x_list, trim_lines)
+  jsonify(x_list, trim_lines, add_levels)
 }
 
 #' @rdname teal_slice

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -239,13 +239,14 @@ print.teal_slice <- function(x, ...) {
 #'
 #' @param x (`list`), possibly recursive, obtained from `teal_slice` or `teal_slices`.
 #' @param trim_lines (`logical(1)`) flag specifying whether to trim lines of the `JSON` string.
+#' @param add_levels (`logical(1)`) whether to add level values if `selected` or `choices` is a `factor`.
 #' @return A `JSON` string representation of the input list.
 #' @keywords internal
 #'
-jsonify <- function(x, trim_lines) {
+jsonify <- function(x, trim_lines, add_levels) {
   checkmate::assert_list(x)
 
-  x_json <- to_json(x)
+  x_json <- to_json(x, add_levels)
   x_json_justified <- justify_json(x_json)
   if (trim_lines) x_json_justified <- trim_lines_json(x_json_justified)
   paste(x_json_justified, collapse = "\n")
@@ -257,18 +258,20 @@ jsonify <- function(x, trim_lines) {
 #' Ensures proper unboxing of list elements.
 #' This function is used by the `format` methods for `teal_slice` and `teal_slices`.
 #' @param x `list`, possibly recursive, obtained from `teal_slice` or `teal_slices`.
+#' @param add_levels (`logical(1)`) whether to add level values if `selected` or `choices` is a `factor`.
 #' @return A `JSON` string.
 #' @keywords internal
 #
 #' @param x (`list`) representation of `teal_slices` object.
 #' @keywords internal
 #'
-to_json <- function(x) {
+to_json <- function(x, add_levels) {
   no_unbox <- function(x) {
     vars <- c("selected", "choices")
     if (is.list(x)) {
       for (var in vars) {
         if (!is.null(x[[var]])) x[[var]] <- I(x[[var]])
+        if (add_levels && is.factor(x[[var]])) x[[paste0(var, "_levels")]] <- I(levels(x[[var]]))
       }
       lapply(x, no_unbox)
     } else {

--- a/R/teal_slices.R
+++ b/R/teal_slices.R
@@ -206,10 +206,11 @@ c.teal_slices <- function(...) {
 #' @rdname teal_slices
 #' @param show_all (`logical(1)`) whether to display non-null elements of constituent `teal_slice` objects
 #' @param trim_lines (`logical(1)`) whether to trim lines
+#' @param add_levels (`logical(1)`) whether to add level values if `selected` or `choices` is a `factor`
 #' @export
 #' @keywords internal
 #'
-format.teal_slices <- function(x, show_all = FALSE, trim_lines = TRUE, ...) {
+format.teal_slices <- function(x, show_all = FALSE, trim_lines = TRUE, add_levels = FALSE, ...) {
   checkmate::assert_flag(show_all)
   checkmate::assert_flag(trim_lines)
 
@@ -221,7 +222,7 @@ format.teal_slices <- function(x, show_all = FALSE, trim_lines = TRUE, ...) {
 
   if (!show_all) slices_list$slices <- lapply(slices_list$slices, function(slice) Filter(Negate(is.null), slice))
 
-  jsonify(slices_list, trim_lines)
+  jsonify(slices_list, trim_lines, add_levels)
 }
 
 

--- a/inst/teal_slices.yml
+++ b/inst/teal_slices.yml
@@ -26,6 +26,14 @@ schemas:
               type: array
               items:
                 type: ['null', string, boolean, number]
+            choices_levels:
+              type: array
+              items:
+                type: ['null', string]
+            selected_levels:
+              type: array
+              items:
+                type: ['null', string]
             keep_na:
               type: ['null', boolean]
             keep_inf:

--- a/man/jsonify.Rd
+++ b/man/jsonify.Rd
@@ -4,12 +4,14 @@
 \alias{jsonify}
 \title{Convert a list to a justified \code{JSON} string}
 \usage{
-jsonify(x, trim_lines)
+jsonify(x, trim_lines, add_levels)
 }
 \arguments{
 \item{x}{(\code{list}), possibly recursive, obtained from \code{teal_slice} or \code{teal_slices}.}
 
 \item{trim_lines}{(\code{logical(1)}) flag specifying whether to trim lines of the \code{JSON} string.}
+
+\item{add_levels}{(\code{logical(1)}) whether to add level values if \code{selected} or \code{choices} is a \code{factor}.}
 }
 \value{
 A \code{JSON} string representation of the input list.

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -31,7 +31,7 @@ as.teal_slice(x)
 
 \method{as.list}{teal_slice}(x, ...)
 
-\method{format}{teal_slice}(x, show_all = FALSE, trim_lines = TRUE, ...)
+\method{format}{teal_slice}(x, show_all = FALSE, trim_lines = TRUE, add_levels = FALSE, ...)
 
 \method{print}{teal_slice}(x, ...)
 }
@@ -77,6 +77,8 @@ of \code{teal.slice} classes. In other methods these are further arguments passe
 only non-NULL elements will be printed.}
 
 \item{trim_lines}{(\code{logical(1)}) indicating whether to trim lines when printing.}
+
+\item{add_levels}{(\code{logical(1)}) whether to add level values if \code{selected} or \code{choices} is a \code{factor}.}
 }
 \value{
 A \code{teal.slice} object. Depending on whether \code{varname} or \code{expr} was specified, the resulting

--- a/man/teal_slices.Rd
+++ b/man/teal_slices.Rd
@@ -30,7 +30,7 @@ as.teal_slices(x)
 
 \method{c}{teal_slices}(...)
 
-\method{format}{teal_slices}(x, show_all = FALSE, trim_lines = TRUE, ...)
+\method{format}{teal_slices}(x, show_all = FALSE, trim_lines = TRUE, add_levels = FALSE, ...)
 
 \method{print}{teal_slices}(x, ...)
 
@@ -65,6 +65,8 @@ Please make sure that adding new filters doesn't fail on target platform before 
 \item{show_all}{(\code{logical(1)}) whether to display non-null elements of constituent \code{teal_slice} objects}
 
 \item{trim_lines}{(\code{logical(1)}) whether to trim lines}
+
+\item{add_levels}{(\code{logical(1)}) whether to add level values if \code{selected} or \code{choices} is a \code{factor}}
 }
 \value{
 \code{teal_slices}, which is an unnamed list of \code{teal_slice} objects.

--- a/man/to_json.Rd
+++ b/man/to_json.Rd
@@ -4,10 +4,12 @@
 \alias{to_json}
 \title{Converts a list to a \code{JSON} string}
 \usage{
-to_json(x)
+to_json(x, add_levels)
 }
 \arguments{
 \item{x}{(\code{list}) representation of \code{teal_slices} object.}
+
+\item{add_levels}{(\code{logical(1)}) whether to add level values if \code{selected} or \code{choices} is a \code{factor}.}
 }
 \value{
 A \code{JSON} string.

--- a/tests/testthat/test-teal_slice-store.R
+++ b/tests/testthat/test-teal_slice-store.R
@@ -128,3 +128,41 @@ test_that("teal_slice store/restore restores mixed `Date`-characters as characte
   tss_restored <- slices_restore(slices_path)
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })
+
+test_that("teal_slice store/restore restores factors as factors in selected and choices", {
+  slices_path <- withr::local_file("slices.json")
+  tss <- teal_slices(
+    teal_slice(
+      dataname = "ADSL",
+      varname = "EOSDTM",
+      choices = factor(c("a", "b", "c")),
+      selected = factor(c("a", "b"))
+    )
+  )
+
+  slices_store(tss, slices_path)
+  tss_restored <- slices_restore(slices_path)
+  expect_s3_class(shiny::isolate(tss_restored[[1]]$selected), "factor")
+  expect_s3_class(shiny::isolate(tss_restored[[1]]$choices), "factor")
+  expect_identical_slice(tss[[1]], tss_restored[[1]])
+})
+
+
+test_that("teal_slice store/restore restores characters as characters in selected and choices", {
+  slices_path <- withr::local_file("slices.json")
+  tss <- teal_slices(
+    teal_slice(
+      dataname = "ADSL",
+      varname = "EOSDTM",
+      choices = c("a", "b", "c"),
+      selected = c("a", "b")
+    )
+  )
+
+  slices_store(tss, slices_path)
+  tss_restored <- slices_restore(slices_path)
+
+  expect_identical(class(shiny::isolate(tss_restored[[1]]$selected)), "character")
+  expect_identical(class(shiny::isolate(tss_restored[[1]]$choices)), "character")
+  expect_identical_slice(tss[[1]], tss_restored[[1]])
+})


### PR DESCRIPTION
Closes #467 
A continuation of https://github.com/insightsengineering/teal.slice/pull/432

In this short PR we enhanced `format` with a new parameter called `add_levels` that allows to store `levels` of `factor` variables for `selected` and `choices` fields. This is only used in `store` where we store levels next to variables in new fields called `selected_levels` and `choices_levels`. Those two fields gets removed on a `restore` procedure. 

I extended tests to prove that results for `factors` and `characters` for `selected` and `choices` are the same when storing and restoring.