### PR TITLE
#467 change factors to characters for selected and choices at teal_slice creation

### DIFF
--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -58,9 +58,9 @@
 #'  requires `dataname` prefix, *e.g.* `data$var == "x"`.
 #' @param choices (optional `vector`) specifying allowed choices;
 #' When specified it should be a subset of values in variable denoted by `varname`;
-#' Type and size depends on variable type. If specified as `factor`, it is converted to `character`.
+#' Type and size depends on variable type. Factors are coerced to character.
 #' @param selected (optional `vector`) of selected values from `choices`;
-#' Type and size depends on variable type. If specified as `factor`, it is converted to `character`.
+#' Type and size depends on variable type. Factors are coerced to character.
 #' @param multiple (optional `logical(1)`) flag specifying whether more than one value can be selected;
 #' only applicable to `ChoicesFilterState` and `LogicalFilterState`
 #' @param keep_na (optional `logical(1)`) flag specifying whether to keep missing values

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -58,9 +58,9 @@
 #'  requires `dataname` prefix, *e.g.* `data$var == "x"`.
 #' @param choices (optional `vector`) specifying allowed choices;
 #' When specified it should be a subset of values in variable denoted by `varname`;
-#' Type and size depends on variable type.
+#' Type and size depends on variable type. If specified as `factor`, it is converted to `character`.
 #' @param selected (optional `vector`) of selected values from `choices`;
-#' Type and size depends on variable type.
+#' Type and size depends on variable type. If specified as `factor`, it is converted to `character`.
 #' @param multiple (optional `logical(1)`) flag specifying whether more than one value can be selected;
 #' only applicable to `ChoicesFilterState` and `LogicalFilterState`
 #' @param keep_na (optional `logical(1)`) flag specifying whether to keep missing values
@@ -155,6 +155,8 @@ teal_slice <- function(dataname,
     )
     formal_args <- formal_args[ts_var_args]
     args <- c(formal_args, list(...))
+    args[c("choices", "selected")] <-
+      lapply(args[c("choices", "selected")], function(x) if (is.factor(x)) as.character(x) else x)
     if (missing(id)) {
       args$id <- get_default_slice_id(args)
     } else {

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -50,10 +50,10 @@ requires \code{dataname} prefix, \emph{e.g.} \code{data$var == "x"}.}
 
 \item{choices}{(optional \code{vector}) specifying allowed choices;
 When specified it should be a subset of values in variable denoted by \code{varname};
-Type and size depends on variable type.}
+Type and size depends on variable type. If specified as \code{factor}, it is converted to \code{character}.}
 
 \item{selected}{(optional \code{vector}) of selected values from \code{choices};
-Type and size depends on variable type.}
+Type and size depends on variable type. If specified as \code{factor}, it is converted to \code{character}.}
 
 \item{keep_na}{(optional \code{logical(1)}) flag specifying whether to keep missing values}
 

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -50,10 +50,10 @@ requires \code{dataname} prefix, \emph{e.g.} \code{data$var == "x"}.}
 
 \item{choices}{(optional \code{vector}) specifying allowed choices;
 When specified it should be a subset of values in variable denoted by \code{varname};
-Type and size depends on variable type. If specified as \code{factor}, it is converted to \code{character}.}
+Type and size depends on variable type. Factors are coerced to character.}
 
 \item{selected}{(optional \code{vector}) of selected values from \code{choices};
-Type and size depends on variable type. If specified as \code{factor}, it is converted to \code{character}.}
+Type and size depends on variable type. Factors are coerced to character.}
 
 \item{keep_na}{(optional \code{logical(1)}) flag specifying whether to keep missing values}
 

--- a/tests/testthat/test-teal_slice-store.R
+++ b/tests/testthat/test-teal_slice-store.R
@@ -143,7 +143,7 @@ testthat::test_that("teal_slice store/restore restores characters as characters 
   slices_store(tss, slices_path)
   tss_restored <- slices_restore(slices_path)
 
-  testthat::expect_identical(class(shiny::isolate(tss_restored[[1]]$selected)), "character")
-  testthat::expect_identical(class(shiny::isolate(tss_restored[[1]]$choices)), "character")
+  testthat::expect_type(shiny::isolate(tss_restored[[1]]$selected), "character")
+  testthat::expect_type(shiny::isolate(tss_restored[[1]]$choices), "character")
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })

--- a/tests/testthat/test-teal_slice-store.R
+++ b/tests/testthat/test-teal_slice-store.R
@@ -128,3 +128,46 @@ test_that("teal_slice store/restore restores mixed `Date`-characters as characte
   tss_restored <- slices_restore(slices_path)
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })
+
+
+
+test_that(
+  "teal_slice store/restore restores factors as characters in selected and choices because they are converted",
+  {
+    slices_path <- withr::local_file("slices.json")
+    tss <- teal_slices(
+      teal_slice(
+        dataname = "ADSL",
+        varname = "EOSDTM",
+        choices = factor(c("a", "b", "c")),
+        selected = factor(c("a", "b"))
+      )
+    )
+
+    slices_store(tss, slices_path)
+    tss_restored <- slices_restore(slices_path)
+    expect_identical(class(shiny::isolate(tss_restored[[1]]$selected)), "character")
+    expect_identical(class(shiny::isolate(tss_restored[[1]]$choices)), "character")
+    expect_identical_slice(tss[[1]], tss_restored[[1]])
+  }
+)
+
+
+test_that("teal_slice store/restore restores characters as characters in selected and choices", {
+  slices_path <- withr::local_file("slices.json")
+  tss <- teal_slices(
+    teal_slice(
+      dataname = "ADSL",
+      varname = "EOSDTM",
+      choices = c("a", "b", "c"),
+      selected = c("a", "b")
+    )
+  )
+
+  slices_store(tss, slices_path)
+  tss_restored <- slices_restore(slices_path)
+
+  expect_identical(class(shiny::isolate(tss_restored[[1]]$selected)), "character")
+  expect_identical(class(shiny::isolate(tss_restored[[1]]$choices)), "character")
+  expect_identical_slice(tss[[1]], tss_restored[[1]])
+})

--- a/tests/testthat/test-teal_slice-store.R
+++ b/tests/testthat/test-teal_slice-store.R
@@ -1,4 +1,4 @@
-test_that("teal_slice store/restore supports saving `POSIXct` timestamps in selected", {
+testthat::test_that("teal_slice store/restore supports saving `POSIXct` timestamps in selected", {
   slices_path <- withr::local_file("slices.json")
 
   time_stamps <- Sys.time() + c(-10 * 60 * 60 * 24, -30, 0)
@@ -23,12 +23,12 @@ test_that("teal_slice store/restore supports saving `POSIXct` timestamps in sele
   tss_restored <- slices_restore(slices_path)
 
   tss_restored_list <- shiny::isolate(shiny::reactiveValuesToList(tss_restored[[1]]))
-  expect_s3_class(tss_restored_list$selected, "POSIXct")
+  testthat::expect_s3_class(tss_restored_list$selected, "POSIXct")
 
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })
 
-test_that("teal_slice store/restore supports saving `Date` dates in selected", {
+testthat::test_that("teal_slice store/restore supports saving `Date` dates in selected", {
   slices_path <- withr::local_file("slices.json")
 
   time_stamps <- Sys.Date() + c(-10 * 600, -30, 0)
@@ -47,12 +47,12 @@ test_that("teal_slice store/restore supports saving `Date` dates in selected", {
   tss_restored <- slices_restore(slices_path)
 
   tss_restored_list <- shiny::isolate(shiny::reactiveValuesToList(tss_restored[[1]]))
-  expect_s3_class(tss_restored_list$selected, "Date")
+  testthat::expect_s3_class(tss_restored_list$selected, "Date")
 
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })
 
-test_that("teal_slice store/restore supports saving `POSIXct` timestamps in choices", {
+testthat::test_that("teal_slice store/restore supports saving `POSIXct` timestamps in choices", {
   slices_path <- withr::local_file("slices.json")
 
   time_stamps <- Sys.time() + c(-10 * 60 * 60 * 24, -30, 0)
@@ -78,12 +78,12 @@ test_that("teal_slice store/restore supports saving `POSIXct` timestamps in choi
   tss_restored <- slices_restore(slices_path)
 
   tss_restored_list <- shiny::isolate(shiny::reactiveValuesToList(tss_restored[[1]]))
-  expect_s3_class(tss_restored_list$choices, "POSIXct")
+  testthat::expect_s3_class(tss_restored_list$choices, "POSIXct")
 
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })
 
-test_that("teal_slice store/restore supports saving `Date` timestamps in choices", {
+testthat::test_that("teal_slice store/restore supports saving `Date` timestamps in choices", {
   slices_path <- withr::local_file("slices.json")
 
   time_stamps <- Sys.Date() + c(-10 * 600, -30, 0)
@@ -103,13 +103,13 @@ test_that("teal_slice store/restore supports saving `Date` timestamps in choices
   tss_restored <- slices_restore(slices_path)
 
   tss_restored_list <- shiny::isolate(shiny::reactiveValuesToList(tss_restored[[1]]))
-  expect_s3_class(tss_restored_list$choices, "Date")
+  testthat::expect_s3_class(tss_restored_list$choices, "Date")
 
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })
 
 
-test_that("teal_slice store/restore restores mixed `Date`-characters as characters in selected", {
+testthat::test_that("teal_slice store/restore restores mixed `Date`-characters as characters in selected", {
   slices_path <- withr::local_file("slices.json")
   tss <- teal_slices(
     teal_slice(
@@ -129,7 +129,7 @@ test_that("teal_slice store/restore restores mixed `Date`-characters as characte
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })
 
-test_that("teal_slice store/restore restores characters as characters in selected and choices", {
+testthat::test_that("teal_slice store/restore restores characters as characters in selected and choices", {
   slices_path <- withr::local_file("slices.json")
   tss <- teal_slices(
     teal_slice(
@@ -143,7 +143,7 @@ test_that("teal_slice store/restore restores characters as characters in selecte
   slices_store(tss, slices_path)
   tss_restored <- slices_restore(slices_path)
 
-  expect_identical(class(shiny::isolate(tss_restored[[1]]$selected)), "character")
-  expect_identical(class(shiny::isolate(tss_restored[[1]]$choices)), "character")
+  testthat::expect_identical(class(shiny::isolate(tss_restored[[1]]$selected)), "character")
+  testthat::expect_identical(class(shiny::isolate(tss_restored[[1]]$choices)), "character")
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })

--- a/tests/testthat/test-teal_slice-store.R
+++ b/tests/testthat/test-teal_slice-store.R
@@ -129,30 +129,6 @@ test_that("teal_slice store/restore restores mixed `Date`-characters as characte
   expect_identical_slice(tss[[1]], tss_restored[[1]])
 })
 
-
-
-test_that(
-  "teal_slice store/restore restores factors as characters in selected and choices because they are converted",
-  {
-    slices_path <- withr::local_file("slices.json")
-    tss <- teal_slices(
-      teal_slice(
-        dataname = "ADSL",
-        varname = "EOSDTM",
-        choices = factor(c("a", "b", "c")),
-        selected = factor(c("a", "b"))
-      )
-    )
-
-    slices_store(tss, slices_path)
-    tss_restored <- slices_restore(slices_path)
-    expect_identical(class(shiny::isolate(tss_restored[[1]]$selected)), "character")
-    expect_identical(class(shiny::isolate(tss_restored[[1]]$choices)), "character")
-    expect_identical_slice(tss[[1]], tss_restored[[1]])
-  }
-)
-
-
 test_that("teal_slice store/restore restores characters as characters in selected and choices", {
   slices_path <- withr::local_file("slices.json")
   tss <- teal_slices(

--- a/tests/testthat/test-teal_slice.R
+++ b/tests/testthat/test-teal_slice.R
@@ -219,3 +219,21 @@ testthat::test_that("teal_slice dataname has to be a string when expr is specifi
     teal_slice(dataname = character(0), id = "x", title = "x", expr = "x == 'x'"), "length"
   )
 })
+
+test_that(
+  "teal_slice converts factors to characters for 'selected' and 'choices' parameters",
+  {
+    slices_path <- withr::local_file("slices.json")
+    tss <- teal_slices(
+      teal_slice(
+        dataname = "ADSL",
+        varname = "EOSDTM",
+        choices = factor(c("a", "b", "c")),
+        selected = factor(c("a", "b"))
+      )
+    )
+
+    expect_identical(class(shiny::isolate(tss_restored[[1]]$selected)), "character")
+    expect_identical(class(shiny::isolate(tss_restored[[1]]$choices)), "character")
+  }
+)


### PR DESCRIPTION
Alternative for #468 that closes #467 as a consequence of #373

We changed the behavior of `teal_slice` that converts `factors` to `characters` for the unified result of `store/restore`.

```r
> slices_path <- withr::local_file("slices.json")
> tss <- teal_slices(
+   teal_slice(
+     dataname = "ADSL",
+     varname = "EOSDTM",
+     choices = factor(c("a", "b", "c")),
+     selected = factor(c("a", "b"))
+   )
+ )
> 
> slices_store(tss, slices_path)
> tss_restored <- slices_restore(slices_path)
> 
> class(shiny::isolate(tss_restored[[1]]$selected))
[1] "character"
> class(shiny::isolate(tss_restored[[1]]$choices))
[1] "character"
> class(shiny::isolate(tss[[1]]$selected))
[1] "character"
> class(shiny::isolate(tss[[1]]$choices))
[1] "character"
```