### PR TITLE
471 remove `CodeClass` from `FilteredData`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.slice 0.4.0.9022
+# teal.slice 0.4.0.9023
 
 ### Miscellaneous
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * Setting filters using a list is now deprecated. Use `teal_slices` and `teal_slice` instead.
 * Removed `CDISCFilteredData` and `CDISCFilteredDataset` and implementing `JoinKeys` handling in their parent classes (`FilteredData` and `DefaultFilteredDataset`).
 * Specifying set of filterable columns is done through `include_varnames` and `exclude_varnames` in `teal_slices`. Specifying `attr(, "filterable")` is hard deprecated.
+* Removed private fields `$code` and `$check` from `FilteredData` class and made appropriate changes to constructor and `init_filtered_data`.
 
 # teal.slice 0.3.0
 

--- a/R/FilteredData-utils.R
+++ b/R/FilteredData-utils.R
@@ -60,12 +60,10 @@ init_filtered_data.TealData <- function(x, # nolint
 
 #' @keywords internal
 #' @export
-init_filtered_data.default <- function(x, join_keys = teal.data::join_keys(), code = NULL, check = FALSE) { # nolint
+init_filtered_data.default <- function(x, join_keys = teal.data::join_keys()) { # nolint
   checkmate::assert_list(x, any.missing = FALSE, names = "unique")
-  checkmate::assert_class(code, "CodeClass", null.ok = TRUE)
   checkmate::assert_class(join_keys, "JoinKeys")
-  checkmate::assert_flag(check)
-  FilteredData$new(x, join_keys = join_keys, code = code, check = check)
+  FilteredData$new(x, join_keys = join_keys)
 }
 
 #' Validate dataset arguments

--- a/R/FilteredData-utils.R
+++ b/R/FilteredData-utils.R
@@ -60,7 +60,7 @@ init_filtered_data.TealData <- function(x, # nolint
 
 #' @keywords internal
 #' @export
-init_filtered_data.default <- function(x, join_keys = teal.data::join_keys()) { # nolint
+init_filtered_data.default <- function(x, join_keys = teal.data::join_keys(), code, check) { # nolint
   checkmate::assert_list(x, any.missing = FALSE, names = "unique")
   checkmate::assert_class(join_keys, "join_keys")
   FilteredData$new(x, join_keys = join_keys)

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -69,7 +69,7 @@ FilteredData <- R6::R6Class( # nolint
     #'   Names of the list will serve as `dataname`.
     #' @param join_keys (`join_keys` or NULL) see [`teal.data::join_keys()`].
     #'
-    initialize = function(data_objects, join_keys = teal.data::join_keys() ) {
+    initialize = function(data_objects, join_keys = teal.data::join_keys()) {
       checkmate::assert_list(data_objects, any.missing = FALSE, min.len = 0, names = "unique")
       # Note the internals of data_objects are checked in set_dataset
       checkmate::assert_class(join_keys, "join_keys")

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -68,20 +68,11 @@ FilteredData <- R6::R6Class( # nolint
     #'   should named elements containing `data.frame` or `MultiAssayExperiment`.
     #'   Names of the list will serve as `dataname`.
     #' @param join_keys (`JoinKeys` or NULL) see [`teal.data::join_keys()`].
-    #' @param code (`CodeClass` or `NULL`) see [`teal.data::CodeClass`].
-    #' @param check (`logical(1)`) whether data has been check against reproducibility.
     #'
-    initialize = function(data_objects, join_keys = teal.data::join_keys(), code = NULL, check = FALSE) {
+    initialize = function(data_objects, join_keys = teal.data::join_keys() ) {
       checkmate::assert_list(data_objects, any.missing = FALSE, min.len = 0, names = "unique")
       # Note the internals of data_objects are checked in set_dataset
       checkmate::assert_class(join_keys, "JoinKeys")
-      checkmate::assert_class(code, "CodeClass", null.ok = TRUE)
-      checkmate::assert_flag(check)
-
-      self$set_check(check)
-      if (!is.null(code)) {
-        self$set_code(code)
-      }
 
       self$set_join_keys(join_keys)
 
@@ -212,21 +203,6 @@ FilteredData <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' Gets the R preprocessing code string that generates the unfiltered datasets.
-    #'
-    #' @param dataname (`character(1)`) name(s) of dataset(s)
-    #'
-    #' @return (`character(1)`) deparsed code
-    #'
-    get_code = function(dataname = self$datanames()) {
-      if (!is.null(private$code)) {
-        paste0(private$code$get_code(dataname), collapse = "\n")
-      } else {
-        paste0("# No pre-processing code provided")
-      }
-    },
-
-    #' @description
     #' Gets filtered or unfiltered dataset.
     #'
     #' For `filtered = FALSE`, the original data set with
@@ -240,15 +216,6 @@ FilteredData <- R6::R6Class( # nolint
       checkmate::assert_flag(filtered)
       data <- private$get_filtered_dataset(dataname)$get_dataset(filtered)
       if (filtered) data() else data
-    },
-
-    #' @description
-    #' Returns whether the datasets in the object has undergone a reproducibility check.
-    #'
-    #' @return `logical`
-    #'
-    get_check = function() {
-      private$.check
     },
 
     #' @description
@@ -369,34 +336,6 @@ FilteredData <- R6::R6Class( # nolint
     set_join_keys = function(join_keys) {
       checkmate::assert_class(join_keys, "JoinKeys")
       private$join_keys <- join_keys
-      invisible(self)
-    },
-
-    #' @description
-    #' Sets whether the datasets in the object have undergone a reproducibility check.
-    #'
-    #' @param check (`logical`) whether datasets have undergone reproducibility check
-    #'
-    #' @return (`self`)
-    #'
-    set_check = function(check) {
-      checkmate::assert_flag(check)
-      private$.check <- check
-      invisible(self)
-    },
-
-    #' @description
-    #' Sets the R preprocessing code for single dataset.
-    #'
-    #' @param code (`CodeClass`)\cr
-    #'   preprocessing code that can be parsed to generate the unfiltered datasets
-    #'
-    #' @return (`self`)
-    #'
-    set_code = function(code) {
-      checkmate::assert_class(code, "CodeClass")
-      logger::log_trace("FilteredData$set_code setting code")
-      private$code <- code
       invisible(self)
     },
 
@@ -1067,12 +1006,6 @@ FilteredData <- R6::R6Class( # nolint
 
     # activate/deactivate filter panel
     filter_panel_active = TRUE,
-
-    # whether the datasets had a reproducibility check
-    .check = FALSE,
-
-    # preprocessing code used to generate the unfiltered datasets as a string
-    code = NULL,
 
     # `reactive` containing teal_slices that can be selected; only active in module-specific mode
     available_teal_slices = NULL,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -43,6 +43,7 @@
   plotly::plot_ly
   shinycssloaders::withSpinner
   shinyWidgets::pickerOptions
+  teal.data::datanames
   teal.widgets::optionalSelectInput
 }
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,11 +1,11 @@
+cloneable
 Forkers
+funder
 Hoffmann
 MultiAssayExperiment
-UI
-cloneable
-funder
 programmatically
 repo
 reproducibility
 subclasses
 subtype
+UI

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -105,17 +105,13 @@ shiny::isolate(datasets$get_filter_state())
 \item \href{#method-FilteredData-set_available_teal_slices}{\code{FilteredData$set_available_teal_slices()}}
 \item \href{#method-FilteredData-get_available_teal_slices}{\code{FilteredData$get_available_teal_slices()}}
 \item \href{#method-FilteredData-get_call}{\code{FilteredData$get_call()}}
-\item \href{#method-FilteredData-get_code}{\code{FilteredData$get_code()}}
 \item \href{#method-FilteredData-get_data}{\code{FilteredData$get_data()}}
-\item \href{#method-FilteredData-get_check}{\code{FilteredData$get_check()}}
 \item \href{#method-FilteredData-get_metadata}{\code{FilteredData$get_metadata()}}
 \item \href{#method-FilteredData-get_join_keys}{\code{FilteredData$get_join_keys()}}
 \item \href{#method-FilteredData-get_filter_overview}{\code{FilteredData$get_filter_overview()}}
 \item \href{#method-FilteredData-get_keys}{\code{FilteredData$get_keys()}}
 \item \href{#method-FilteredData-set_dataset}{\code{FilteredData$set_dataset()}}
 \item \href{#method-FilteredData-set_join_keys}{\code{FilteredData$set_join_keys()}}
-\item \href{#method-FilteredData-set_check}{\code{FilteredData$set_check()}}
-\item \href{#method-FilteredData-set_code}{\code{FilteredData$set_code()}}
 \item \href{#method-FilteredData-get_filter_state}{\code{FilteredData$get_filter_state()}}
 \item \href{#method-FilteredData-format}{\code{FilteredData$format()}}
 \item \href{#method-FilteredData-print}{\code{FilteredData$print()}}
@@ -147,12 +143,7 @@ shiny::isolate(datasets$get_filter_state())
 \subsection{Method \code{new()}}{
 Initialize a \code{FilteredData} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredData$new(
-  data_objects,
-  join_keys = teal.data::join_keys(),
-  code = NULL,
-  check = FALSE
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilteredData$new(data_objects, join_keys = teal.data::join_keys())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -163,10 +154,6 @@ should named elements containing \code{data.frame} or \code{MultiAssayExperiment
 Names of the list will serve as \code{dataname}.}
 
 \item{\code{join_keys}}{(\code{JoinKeys} or NULL) see \code{\link[teal.data:join_keys]{teal.data::join_keys()}}.}
-
-\item{\code{code}}{(\code{CodeClass} or \code{NULL}) see \code{\link[teal.data:CodeClass]{teal.data::CodeClass}}.}
-
-\item{\code{check}}{(\code{logical(1)}) whether data has been check against reproducibility.}
 }
 \if{html}{\out{</div>}}
 }
@@ -289,26 +276,6 @@ This can be used for the \verb{Show R Code} generation.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-FilteredData-get_code"></a>}}
-\if{latex}{\out{\hypertarget{method-FilteredData-get_code}{}}}
-\subsection{Method \code{get_code()}}{
-Gets the R preprocessing code string that generates the unfiltered datasets.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredData$get_code(dataname = self$datanames())}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{dataname}}{(\code{character(1)}) name(s) of dataset(s)}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-(\code{character(1)}) deparsed code
-}
-}
-\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FilteredData-get_data"></a>}}
 \if{latex}{\out{\hypertarget{method-FilteredData-get_data}{}}}
 \subsection{Method \code{get_data()}}{
@@ -328,19 +295,6 @@ For \code{filtered = FALSE}, the original data set with
 \item{\code{filtered}}{(\code{logical}) whether to return a filtered or unfiltered dataset}
 }
 \if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-FilteredData-get_check"></a>}}
-\if{latex}{\out{\hypertarget{method-FilteredData-get_check}{}}}
-\subsection{Method \code{get_check()}}{
-Returns whether the datasets in the object has undergone a reproducibility check.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredData$get_check()}\if{html}{\out{</div>}}
-}
-
-\subsection{Returns}{
-\code{logical}
 }
 }
 \if{html}{\out{<hr>}}
@@ -481,47 +435,6 @@ Set the \code{join_keys}.
 }
 \subsection{Returns}{
 (\code{self}) invisibly this \code{FilteredData}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-FilteredData-set_check"></a>}}
-\if{latex}{\out{\hypertarget{method-FilteredData-set_check}{}}}
-\subsection{Method \code{set_check()}}{
-Sets whether the datasets in the object have undergone a reproducibility check.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredData$set_check(check)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{check}}{(\code{logical}) whether datasets have undergone reproducibility check}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-(\code{self})
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-FilteredData-set_code"></a>}}
-\if{latex}{\out{\hypertarget{method-FilteredData-set_code}{}}}
-\subsection{Method \code{set_code()}}{
-Sets the R preprocessing code for single dataset.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredData$set_code(code)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{code}}{(\code{CodeClass})\cr
-preprocessing code that can be parsed to generate the unfiltered datasets}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-(\code{self})
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -22,50 +22,6 @@ testthat::test_that("constructor accepts join_keys to be join_keys or NULL", {
   )
 })
 
-testthat::test_that("constructor accepts code to be CodeClass or NULL", {
-  mockcodeclass <- R6::R6Class(classname = "CodeClass")
-  testthat::expect_no_error(
-    FilteredData$new(list(iris = list(dataset = iris)), code = mockcodeclass$new())
-  )
-  testthat::expect_no_error(
-    FilteredData$new(list(iris = list(dataset = iris)), code = NULL)
-  )
-  testthat::expect_error(
-    FilteredData$new(list(iris = list(dataset = iris)), code = list(), "Assertion on 'code' failed")
-  )
-})
-
-testthat::test_that("constructor accepts check to be a flag", {
-  testthat::expect_no_error(
-    FilteredData$new(list(iris = list(dataset = iris)), check = TRUE)
-  )
-  testthat::expect_error(
-    FilteredData$new(list(iris = list(dataset = iris)), check = NULL, "Assertion on 'check' failed")
-  )
-  testthat::expect_error(
-    FilteredData$new(list(iris = list(dataset = iris)), check = logical(0), "Assertion on 'check' failed")
-  )
-})
-
-testthat::test_that("FilteredData preserves the check field when check is TRUE", {
-  code <- teal.data:::CodeClass$new()$set_code("df_1 <- data.frame(x = 1:10)")
-
-  filtered_data <- FilteredData$new(
-    list("df_1" = list(dataset = data.frame(x = 1:10))),
-    code = code,
-    check = FALSE
-  )
-  testthat::expect_false(filtered_data$get_check())
-
-  filtered_data <- FilteredData$new(
-    list("df_1" = list(dataset = data.frame(x = 1:10))),
-    code = code,
-    check = TRUE
-  )
-  testthat::expect_true(filtered_data$get_check())
-})
-
-
 # datanames ----
 testthat::test_that("filtered_data$datanames returns character vector of datasets names", {
   dataset <- list(dataset = iris)
@@ -204,23 +160,6 @@ testthat::test_that("get_metadata returns metadata if dataset exists", {
   )
   testthat::expect_equal(filtered_data$get_metadata("iris"), list(E = TRUE))
   testthat::expect_null(filtered_data$get_metadata("iris2"))
-})
-
-
-# get_code ----
-testthat::test_that("get_code returns the code passed to CodeClass$set_code", {
-  code <- teal.data:::CodeClass$new()
-  code$set_code("'preprocessing code'", "iris")
-  filtered_data <- FilteredData$new(
-    list(iris = list(dataset = head(iris))),
-    code = code
-  )
-  testthat::expect_equal(filtered_data$get_code(), "\"preprocessing code\"")
-})
-
-testthat::test_that("get_code returns a string when FilteredData has no code", {
-  filtered_data <- FilteredData$new(data_objects = list())
-  testthat::expect_identical(filtered_data$get_code(), "# No pre-processing code provided")
 })
 
 

--- a/tests/testthat/test-init_filtered_data.R
+++ b/tests/testthat/test-init_filtered_data.R
@@ -24,27 +24,9 @@ testthat::test_that("init_filtered_data.default asserts x has unique names", {
   )
 })
 
-testthat::test_that("init_filtered_data.default asserts code is `CodeClass`", {
-  testthat::expect_error(
-    init_filtered_data(list("iris" = list(dataset = iris)), code = "test"),
-    regexp = "Assertion on 'code' failed: Must inherit from class 'CodeClass', but has class 'character'."
-  )
-})
-
-testthat::test_that("init_filtered_data.default accepts NULL passed to code", {
-  testthat::expect_no_error(init_filtered_data(list("iris" = list(dataset = iris)), code = NULL))
-})
-
 testthat::test_that("init_filtered_data.default asserts join_keys is `join_keys`", {
   testthat::expect_error(
     init_filtered_data(list("iris" = list(dataset = iris)), join_keys = "test"),
     regexp = "Assertion on 'join_keys' failed: Must inherit from class 'join_keys', but has class 'character'."
-  )
-})
-
-testthat::test_that("init_filtered_data.default asserts check is logical(1)", {
-  testthat::expect_error(
-    init_filtered_data(list("iris" = list(dataset = iris)), check = "test"),
-    regexp = "Assertion on 'check' failed: Must be of type 'logical flag', not 'character'."
   )
 })


### PR DESCRIPTION
Removed private fields `$code` and `$check` from `FilteredData` class and all associated methods.
Removed `code` and `check` arguments from `init_filtered_data.default`.

[companion](https://github.com/insightsengineering/teal/pull/964)