### PR TITLE
rm pkg name from bioc pkg refs in Config/Needs/verdepcheck

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,8 +64,8 @@ Config/Needs/verdepcheck: rstudio/shiny, rstudio/bslib, mllg/checkmate,
     daroczig/logger, plotly/plotly, r-lib/R6, daattali/shinycssloaders,
     daattali/shinyjs, dreamRs/shinyWidgets, insightsengineering/teal.data,
     insightsengineering/teal.logger, insightsengineering/teal.widgets,
-    yihui/knitr, MultiAssayExperiment=bioc::MultiAssayExperiment,
-    SummarizedExperiment=bioc::SummarizedExperiment, r-lib/testthat,
+    yihui/knitr, bioc::MultiAssayExperiment,
+    bioc::SummarizedExperiment, r-lib/testthat,
     r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8


### PR DESCRIPTION
It seems that `package=(...)` syntax is not supported for bioc refs:

```
r$> pkgdepends::parse_pkg_ref("bioc::MultiAssayExperiment")$package
[1] "MultiAssayExperiment"

r$> pkgdepends::parse_pkg_ref("MultiAssayExperiment=bioc::MultiAssayExperiment")$package
[1] NA
```

This doesn't fail and it has no impact on this repo but it has for all the repos that uses teal.slice -> [example](https://github.com/insightsengineering/teal.transform/actions/runs/6918171659/job/18820132789#step:6:442)