### PR TITLE
update repo roster link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ If you encounter a bug or you have a feature request - please file an issue. For
 
 ### Stargazers
 
-[![Stargazers repo roster for @insightsengineering/teal.slice](https://reporoster.com/stars/insightsengineering/teal.slice)](https://github.com/insightsengineering/teal.slice/stargazers)
+[![Stargazers repo roster for @insightsengineering/teal.slice](http://reporoster.com/stars/insightsengineering/teal.slice)](https://github.com/insightsengineering/teal.slice/stargazers)
 
 ### Forkers
 
-[![Forkers repo roster for @insightsengineering/teal.slice](https://reporoster.com/forks/insightsengineering/teal.slice)](https://github.com/insightsengineering/teal.slice/network/members)
+[![Forkers repo roster for @insightsengineering/teal.slice](http://reporoster.com/forks/insightsengineering/teal.slice)](https://github.com/insightsengineering/teal.slice/network/members)


### PR DESCRIPTION
Related with https://github.com/insightsengineering/teal/issues/949, updating the link to `reporoster` in README.