### PR TITLE
Corrects mapping of parent join_keys columns when merging 2 data frames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
     shinycssloaders (>= 1.0.0),
     shinyjs,
     shinyWidgets (>= 0.6.2),
-    teal.data (>= 0.3.0.9018),
+    teal.data (>= 0.3.0.9029),
     teal.logger (>= 0.1.1),
     teal.widgets (>= 0.4.0),
     utils

--- a/R/FilteredDatasetDataframe.R
+++ b/R/FilteredDatasetDataframe.R
@@ -122,8 +122,8 @@ DataframeFilteredDataset <- R6::R6Class( # nolint
 
       if (!identical(parent_dataname, character(0))) {
         join_keys <- private$join_keys
-        parent_keys <- names(join_keys)
-        dataset_keys <- unname(join_keys)
+        parent_keys <- unname(join_keys)
+        dataset_keys <- names(join_keys)
 
         y_arg <- if (length(parent_keys) == 0L) {
           parent_dataname
@@ -240,11 +240,10 @@ DataframeFilteredDataset <- R6::R6Class( # nolint
       # Gets filter overview subjects number and returns a list
       # of the number of subjects of filtered/non-filtered datasets
       subject_keys <- if (length(private$parent_name) > 0) {
-        private$join_keys
+        names(private$join_keys)
       } else {
         self$get_keys()
       }
-
       dataset <- self$get_dataset()
       data_filtered <- self$get_dataset(TRUE)
       if (length(subject_keys) == 0) {

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -35,7 +35,6 @@ testthat::test_that("filtered_data$datanames returns character vector of dataset
 
 testthat::test_that("datanames are ordered topologically from parent to child", {
   jk <- teal.data::join_keys(teal.data::join_key("parent", "child", c("id" = "id")))
-  teal.data::parents(jk) <- list(child = "parent")
   iris2 <- transform(iris, id = seq_len(nrow(iris)))
   filtered_data <- FilteredData$new(
     list(
@@ -94,7 +93,6 @@ testthat::test_that("set_datasets creates FilteredDataset object linked with par
     )
   )
   jk <- teal.data::join_keys(teal.data::join_key("parent", "child", c("id" = "id")))
-  teal.data::parents(jk) <- list(child = "parent")
   iris2 <- transform(iris, id = seq_len(nrow(iris)))
   filtered_data <- test_class$new(data_objects = list(), join_keys = jk)
   filtered_data$set_dataset(data = head(iris), dataname = "parent")
@@ -627,10 +625,9 @@ testthat::test_that("get_filter_overview returns overview data.frame with filter
 
 testthat::test_that("get_filter_overview return counts based on reactive filtering by ancestors", {
   jk <- teal.data::join_keys(
-    teal.data::join_key("child", "parent", c("id" = "id")),
-    teal.data::join_key("grandchild", "child", c("id" = "id"))
+    teal.data::join_key("parent", "child", c("id" = "id")),
+    teal.data::join_key("child", "grandchild", c("id" = "id"))
   )
-  teal.data::parents(jk) <- list(child = "parent", grandchild = "child")
   iris2 <- transform(iris, id = seq_len(nrow(iris)))
   filtered_data <- FilteredData$new(
     list(


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #502 _(and CI in `teal@main`)_

#### Context

A `join_key("d1", "d2", c("d1_k" = "d2_k"))` will create a symetrical relationship between "d1" and "d2", where "d1" is the parent of "d2".

The key mapping is inverted for (d2, d1), where key is stored as`c("d2_k" = "d1_k")`.

So when the join_key is being extracted (`jk[dataset_1, dataset_2]`), the key columns for `dataset_1` ("d2" in previous line) is obtained via `names()`, while the columns of dataset_2 are present in the values (`unname()`)

#### Changes description

- [x] Corrects the retrieval of column specification to use in merge operation and filter overview
- [x] Add test in {teal.slice}
- [x] Removes `teal.data::parents(..) <- ...` in favor of new behavior that defines this parent-child relationship in `join_key` constructor

note: As far as I can see in the codebase, only `...DataFrames` use parent-child relationship