### PR TITLE
490 error on GRAN

### DIFF
--- a/R/teal_slices.R
+++ b/R/teal_slices.R
@@ -271,8 +271,9 @@ setdiff_teal_slices <- function(x, y) {
 #'
 coalesce_r <- function(x) {
   checkmate::assert_list(x)
-  if (all(vapply(x, is.atomic, logical(1L)))) {
-    return(Filter(Negate(is.null), x)[[1L]])
+  xnn <- Filter(Negate(is.null), x)
+  if (all(vapply(xnn, is.atomic, logical(1L)))) {
+    return(xnn[[1L]])
   }
   lapply(x, checkmate::assert_list, names = "named", null.ok = TRUE, .var.name = "list element")
   all_names <- unique(unlist(lapply(x, names)))


### PR DESCRIPTION
Fixes https://github.com/insightsengineering/coredev-tasks/issues/490

As of `R 4.4.0` `NULL` is no loner considered `atomic`, which interrupted the logic in `coalesce_r`. The logic has been updated.
