### PR TITLE
use demos to store examples for internal functions

### DIFF
--- a/R/FilterState-utils.R
+++ b/R/FilterState-utils.R
@@ -19,6 +19,9 @@
 #' }
 #' @param ... additional arguments to be saved as a list in `private$extras` field
 #'
+#' @examples
+#' if (interactive()) demo("init_filter_state", "teal.slice")
+#'
 #' @seealso check examples here `vignette("internal_functions_example", package = "teal.slice")`.
 #'
 #' @return `FilterState` object

--- a/demo/00Index
+++ b/demo/00Index
@@ -1,0 +1,1 @@
+init_filter_state    FilterState class utilities

--- a/demo/init_filter_state.R
+++ b/demo/init_filter_state.R
@@ -1,0 +1,43 @@
+### Examples for init_filter_state ###
+###    for developer use only
+###
+###                   CoreDev Team ###
+
+require(teal.slice)
+
+readline("create filter state >")
+
+filter_state <- teal.slice:::init_filter_state(
+  x = c(1:10, NA, Inf),
+  x_reactive = reactive(c(1:10, NA, Inf)),
+  slice = teal_slice(
+    varname = "varname",
+    dataname = "dataname"
+  )
+)
+
+shiny::isolate(filter_state$get_call())
+
+readline("next: set state >")
+
+filter_state$set_state(
+  teal_slice("dataname", "varname", selected = c(3.1, 7.3), keep_na = TRUE)
+)
+
+shiny::isolate(filter_state$get_call())
+
+readline("next: continue to application >")
+
+shinyApp(
+  ui = fluidPage(
+    filter_state$ui(id = "app"),
+    verbatimTextOutput("call")
+  ),
+  server = function(input, output, session) {
+    filter_state$server("app")
+
+    output$call <- renderText(
+      deparse1(filter_state$get_call(), collapse = "\n")
+    )
+  }
+)

--- a/man/init_filter_state.Rd
+++ b/man/init_filter_state.Rd
@@ -40,6 +40,10 @@ specifying whether condition calls should be prefixed by \code{dataname}. Possib
 \description{
 Initializes \code{FilterState} depending on a variable class.\cr
 }
+\examples{
+if (interactive()) demo("init_filter_state", "teal.slice")
+
+}
 \seealso{
 check examples here \code{vignette("internal_functions_example", package = "teal.slice")}.
 }


### PR DESCRIPTION
Examples using internal functions are converted to demos. See `?utils::demo`.

Added `demo/` directory in package root.
`demo/` contains `00Index` file (required), which lists all demos and their descriptions. (A minimum of 3 spaces are required as column separator.)
`demo/` contains examples taken from `FilterState-utils.R` with some `readline` calls for pacing.
`FilterState-utils` examples call the demo under `if (interactive())`.