### PR TITLE
Skip tests/examples when packages in Suggest section are not installed

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -52,7 +52,7 @@
 #' isolate(datasets$get_filter_state())
 #' isolate(datasets$get_call("iris"))
 #' isolate(datasets$get_call("mtcars"))
-#'
+#' @examplesIf requireNamespace("MultiAssayExperiment")
 #' ### set_filter_state
 #'
 #' utils::data(miniACC, package = "MultiAssayExperiment")

--- a/R/FilteredDataset-utils.R
+++ b/R/FilteredDataset-utils.R
@@ -40,6 +40,7 @@
 #'   shinyApp(ui, server)
 #' }
 #'
+#' @examplesIf requireNamespace("MultiAssayExperiment")
 #' # MAEFilteredDataset example
 #' library(MultiAssayExperiment)
 #' data(miniACC)

--- a/R/FilteredDatasetMAE.R
+++ b/R/FilteredDatasetMAE.R
@@ -2,7 +2,7 @@
 
 #' @title `MAEFilteredDataset` `R6` class
 #' @keywords internal
-#' @examples
+#' @examplesIf requireNamespace("MultiAssayExperiment")
 #' # use non-exported function from teal.slice
 #' MAEFilteredDataset <- getFromNamespace("MAEFilteredDataset", "teal.slice")
 #'

--- a/R/filter_panel_api.R
+++ b/R/filter_panel_api.R
@@ -23,22 +23,53 @@
 #' @seealso [`teal_slice`]
 #'
 #' @examples
-#' if (requireNamespace("MultiAssayExperiment", quietly = TRUE)) {
-#'   library(MultiAssayExperiment)
-#'   data(miniACC)
-#' } else {
-#'   miniACC <- data.frame()
-#' }
-#'
 #' datasets <- init_filtered_data(
 #'   x = list(
 #'     iris = list(dataset = iris),
-#'     mae = list(dataset = miniACC)
+#'     mtcars = list(dataset = mtcars)
 #'   )
 #' )
 #' fs <- teal_slices(
 #'   teal_slice(dataname = "iris", varname = "Species", selected = c("setosa", "versicolor")),
 #'   teal_slice(dataname = "iris", varname = "Sepal.Length", selected = c(5.1, 6.4)),
+#'   teal_slice(dataname = "mtcars", varname = "gear", selected = c(4, 5)),
+#'   teal_slice(dataname = "mtcars", varname = "carb", selected = c(4, 10))
+#' )
+#'
+#' # set initial filter state
+#' set_filter_state(datasets, filter = fs)
+#'
+#' # get filter state
+#' get_filter_state(datasets)
+#'
+#' # modify filter state
+#' set_filter_state(
+#'   datasets,
+#'   teal_slices(
+#'     teal_slice(dataname = "iris", varname = "Species", selected = "setosa", keep_na = TRUE)
+#'   )
+#' )
+#'
+#' # remove specific filters
+#' remove_filter_state(
+#'   datasets,
+#'   teal_slices(
+#'     teal_slice(dataname = "iris", varname = "Species"),
+#'     teal_slice(dataname = "mtcars", varname = "gear"),
+#'     teal_slice(dataname = "mtcars", varname = "carb")
+#'   )
+#' )
+#'
+#' # remove all states
+#' clear_filter_states(datasets)
+#' @examplesIf requireNamespace("MultiAssayExperiment")
+#'
+#' # Requires MultiAssayExperiment from Bioconductor
+#' library(MultiAssayExperiment)
+#' data(miniACC)
+#'
+#' datasets <- init_filtered_data(x = list(mae = list(dataset = miniAcc)))
+#' fs <- teal_slices(
 #'   teal_slice(
 #'     dataname = "mae", varname = "years_to_birth", selected = c(30, 50),
 #'     keep_na = TRUE, keep_inf = FALSE
@@ -67,7 +98,7 @@
 #' set_filter_state(
 #'   datasets,
 #'   teal_slices(
-#'     teal_slice(dataname = "iris", varname = "Species", selected = "setosa", keep_na = TRUE)
+#'     teal_slice(dataname = "mae", varname = "years_to_birth", selected = c(40, 60))
 #'   )
 #' )
 #'
@@ -75,7 +106,6 @@
 #' remove_filter_state(
 #'   datasets,
 #'   teal_slices(
-#'     teal_slice(dataname = "iris", varname = "Species"),
 #'     teal_slice(dataname = "mae", varname = "years_to_birth"),
 #'     teal_slice(dataname = "mae", varname = "vital_status")
 #'   )

--- a/R/filter_panel_api.R
+++ b/R/filter_panel_api.R
@@ -23,8 +23,12 @@
 #' @seealso [`teal_slice`]
 #'
 #' @examples
-#' library(MultiAssayExperiment)
-#' data(miniACC)
+#' if (requireNamespace("MultiAssayExperiment", quietly = TRUE)) {
+#'   library(MultiAssayExperiment)
+#'   data(miniACC)
+#' } else {
+#'   miniACC <- data.frame()
+#' }
 #'
 #' datasets <- init_filtered_data(
 #'   x = list(

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -62,7 +62,7 @@ datasets$set_filter_state(
 isolate(datasets$get_filter_state())
 isolate(datasets$get_call("iris"))
 isolate(datasets$get_call("mtcars"))
-
+\dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 ### set_filter_state
 
 utils::data(miniACC, package = "MultiAssayExperiment")
@@ -90,7 +90,7 @@ fs <-
   )
 datasets$set_filter_state(state = fs)
 isolate(datasets$get_filter_state())
-
+\dontshow{\}) # examplesIf}
 }
 \keyword{internal}
 \section{Methods}{

--- a/man/MAEFilteredDataset.Rd
+++ b/man/MAEFilteredDataset.Rd
@@ -9,6 +9,7 @@
 \code{MAEFilteredDataset} \code{R6} class
 }
 \examples{
+\dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # use non-exported function from teal.slice
 MAEFilteredDataset <- getFromNamespace("MAEFilteredDataset", "teal.slice")
 
@@ -30,7 +31,7 @@ fs <- teal_slices(
 )
 dataset$set_filter_state(state = fs)
 isolate(dataset$get_filter_state())
-
+\dontshow{\}) # examplesIf}
 }
 \keyword{internal}
 \section{Super class}{

--- a/man/filter_state_api.Rd
+++ b/man/filter_state_api.Rd
@@ -39,22 +39,54 @@ containing a \code{teal_slice} for every existing \code{FilterState}
 Set, get and remove filter states of \code{FilteredData} object.
 }
 \examples{
-if (requireNamespace("MultiAssayExperiment", quietly = TRUE)) {
-  library(MultiAssayExperiment)
-  data(miniACC)
-} else {
-  miniACC <- data.frame()
-}
-
 datasets <- init_filtered_data(
   x = list(
     iris = list(dataset = iris),
-    mae = list(dataset = miniACC)
+    mtcars = list(dataset = mtcars)
   )
 )
 fs <- teal_slices(
   teal_slice(dataname = "iris", varname = "Species", selected = c("setosa", "versicolor")),
   teal_slice(dataname = "iris", varname = "Sepal.Length", selected = c(5.1, 6.4)),
+  teal_slice(dataname = "mtcars", varname = "gear", selected = c(4, 5)),
+  teal_slice(dataname = "mtcars", varname = "carb", selected = c(4, 10))
+)
+
+# set initial filter state
+set_filter_state(datasets, filter = fs)
+
+# get filter state
+get_filter_state(datasets)
+
+# modify filter state
+set_filter_state(
+  datasets,
+  teal_slices(
+    teal_slice(dataname = "iris", varname = "Species", selected = "setosa", keep_na = TRUE)
+  )
+)
+
+# remove specific filters
+remove_filter_state(
+  datasets,
+  teal_slices(
+    teal_slice(dataname = "iris", varname = "Species"),
+    teal_slice(dataname = "mtcars", varname = "gear"),
+    teal_slice(dataname = "mtcars", varname = "carb")
+  )
+)
+
+# remove all states
+clear_filter_states(datasets)
+\dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+
+# Requires MultiAssayExperiment from Bioconductor
+library(MultiAssayExperiment)
+data(miniACC)
+
+datasets <- init_filtered_data(x = list(mae = list(dataset = miniAcc))
+)
+fs <- teal_slices(
   teal_slice(
     dataname = "mae", varname = "years_to_birth", selected = c(30, 50),
     keep_na = TRUE, keep_inf = FALSE
@@ -83,7 +115,7 @@ get_filter_state(datasets)
 set_filter_state(
   datasets,
   teal_slices(
-    teal_slice(dataname = "iris", varname = "Species", selected = "setosa", keep_na = TRUE)
+    teal_slice(dataname = "mae", varname = "years_to_birth", selected = c(40, 60))
   )
 )
 
@@ -91,7 +123,6 @@ set_filter_state(
 remove_filter_state(
   datasets,
   teal_slices(
-    teal_slice(dataname = "iris", varname = "Species"),
     teal_slice(dataname = "mae", varname = "years_to_birth"),
     teal_slice(dataname = "mae", varname = "vital_status")
   )
@@ -99,6 +130,7 @@ remove_filter_state(
 
 # remove all states
 clear_filter_states(datasets)
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link{teal_slice}}

--- a/man/filter_state_api.Rd
+++ b/man/filter_state_api.Rd
@@ -39,8 +39,12 @@ containing a \code{teal_slice} for every existing \code{FilterState}
 Set, get and remove filter states of \code{FilteredData} object.
 }
 \examples{
-library(MultiAssayExperiment)
-data(miniACC)
+if (requireNamespace("MultiAssayExperiment", quietly = TRUE)) {
+  library(MultiAssayExperiment)
+  data(miniACC)
+} else {
+  miniACC <- data.frame()
+}
 
 datasets <- init_filtered_data(
   x = list(

--- a/man/init_filtered_dataset.Rd
+++ b/man/init_filtered_dataset.Rd
@@ -69,6 +69,7 @@ if (interactive()) {
   shinyApp(ui, server)
 }
 
+\dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # MAEFilteredDataset example
 library(MultiAssayExperiment)
 data(miniACC)
@@ -91,6 +92,6 @@ server <- function(input, output, session) {
 if (interactive()) {
   shinyApp(ui, server)
 }
-
+\dontshow{\}) # examplesIf}
 }
 \keyword{internal}

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -1,5 +1,6 @@
 # initialize ----
 testthat::test_that("constructor accepts all types of datasets", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
 
   testthat::expect_no_error(FilteredData$new(list("logical" = c(TRUE, FALSE))))
@@ -718,6 +719,8 @@ testthat::test_that("srv_active - clicking remove_all button clears filters", {
 
 # get_filter_count
 testthat::test_that("get_filter_count properly tallies active filter states", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
+  utils::data(miniACC, package = "MultiAssayExperiment")
   test_class <- R6::R6Class(
     classname = "test_class",
     inherit = FilteredData,
@@ -753,6 +756,8 @@ testthat::test_that("get_filter_count properly tallies active filter states for 
       }
     )
   )
+  testthat::skip_if_not_installed("MultiAssayExperiment")
+  utils::data(miniACC, package = "MultiAssayExperiment")
   datasets <- test_class$new(
     list(
       iris = list(dataset = iris),

--- a/tests/testthat/test-MAEFilterStates.R
+++ b/tests/testthat/test-MAEFilterStates.R
@@ -1,7 +1,7 @@
-utils::data(miniACC, package = "MultiAssayExperiment")
-
 # initialize ----
 testthat::test_that("constructor accepts a MultiAssayExperiment", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
+  utils::data(miniACC, package = "MultiAssayExperiment")
   testthat::expect_no_error(
     MAEFilterStates$new(data = miniACC, dataname = "miniACC")
   )
@@ -13,6 +13,8 @@ testthat::test_that("constructor accepts a MultiAssayExperiment", {
 
 # get_filter_state ----
 testthat::test_that("get_filter_state returns `teal_slices` with include_varname by default and count_type=none", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
+  utils::data(miniACC, package = "MultiAssayExperiment")
   filter_states <- MAEFilterStates$new(data = miniACC, dataname = "miniACC")
   fs <- teal_slices(
     count_type = "none",
@@ -27,6 +29,8 @@ testthat::test_that("get_filter_state returns `teal_slices` with include_varname
 
 # get_call ----
 testthat::test_that("get_call returns subsetByColData call with varnames prefixed by dataname$", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
+  utils::data(miniACC, package = "MultiAssayExperiment")
   filter_states <- MAEFilterStates$new(data = miniACC, dataname = "miniacc")
   filter_states$set_filter_state(
     teal_slices(

--- a/tests/testthat/test-MAEFilteredDataset.R
+++ b/tests/testthat/test-MAEFilteredDataset.R
@@ -1,5 +1,6 @@
 # initialize ----
 testthat::test_that("constructor accepts a MultiAssayExperiment object", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   testthat::expect_no_error(MAEFilteredDataset$new(dataset = miniACC, dataname = "miniACC"))
   testthat::expect_error(
@@ -13,6 +14,7 @@ testthat::test_that("constructor accepts a MultiAssayExperiment object", {
 })
 
 testthat::test_that("filter_states list is initialized with names of experiments", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   testfd <- R6::R6Class(
     "testfd",
     inherit = MAEFilteredDataset,
@@ -30,6 +32,7 @@ testthat::test_that("filter_states list is initialized with names of experiments
 
 # format ---
 testthat::test_that("format returns properly formatted string", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   filtered_dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
   fs <- teal_slices(
@@ -59,6 +62,7 @@ testthat::test_that("format returns properly formatted string", {
 
 # print ---
 testthat::test_that("print returns properly formatted string", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   filtered_dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
   fs <- teal_slices(
@@ -88,6 +92,7 @@ testthat::test_that("print returns properly formatted string", {
 
 # get_call ----
 testthat::test_that("get_call returns NULL when no filter applied", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   filtered_dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniACC")
   get_call_output <- shiny::isolate(filtered_dataset$get_call())
@@ -95,6 +100,7 @@ testthat::test_that("get_call returns NULL when no filter applied", {
 })
 
 testthat::test_that("get_call returns a call with applying filter", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   filtered_dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
   fs <- teal_slices(
@@ -131,6 +137,7 @@ testthat::test_that("get_call returns a call with applying filter", {
 
 # get_filter_overview ----
 testthat::test_that("get_filter_overview_info returns overview matrix for MAEFilteredDataset without filtering", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   filtered_dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniACC")
   testthat::expect_equal(
@@ -146,6 +153,7 @@ testthat::test_that("get_filter_overview_info returns overview matrix for MAEFil
 })
 
 testthat::test_that("get_filter_overview_info returns overview matrix for MAEFilteredDataset with filtering", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   filtered_dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
   fs <- teal_slices(
@@ -177,6 +185,7 @@ testthat::test_that("get_filter_overview_info returns overview matrix for MAEFil
 testthat::test_that(
   "MAEFilteredDataset$set_filter_state sets filters in `FilterStates` specified by `teal_slices",
   code = {
+    testthat::skip_if_not_installed("MultiAssayExperiment")
     utils::data(miniACC, package = "MultiAssayExperiment")
     dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
     fs <- teal_slices(
@@ -217,6 +226,7 @@ testthat::test_that(
 testthat::test_that(
   "MAEFilteredDataset$set_filter_state only acceps `teal_slices",
   code = {
+    testthat::skip_if_not_installed("MultiAssayExperiment")
     utils::data(miniACC, package = "MultiAssayExperiment")
     dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
     fs <- list(
@@ -236,6 +246,7 @@ testthat::test_that(
 testthat::test_that(
   "MAEFilteredDataset$get_filter_state returns list identical to input",
   code = {
+    testthat::skip_if_not_installed("MultiAssayExperiment")
     utils::data(miniACC, package = "MultiAssayExperiment")
     dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
     fs <- teal_slices(
@@ -268,6 +279,7 @@ testthat::test_that(
 testthat::test_that(
   "MAEFilteredDataset$remove_filter_state removes desired filter",
   code = {
+    testthat::skip_if_not_installed("MultiAssayExperiment")
     utils::data(miniACC, package = "MultiAssayExperiment")
     dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
     fs <- teal_slices(
@@ -297,6 +309,7 @@ testthat::test_that(
 testthat::test_that(
   "MAEFilteredDataset$remove_filter_state only accepts `teal_slices",
   code = {
+    testthat::skip_if_not_installed("MultiAssayExperiment")
     utils::data(miniACC, package = "MultiAssayExperiment")
     dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
     fs <- teal_slices(
@@ -318,6 +331,7 @@ testthat::test_that(
 
 # UI actions ----
 testthat::test_that("remove_filters button removes all filters", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   filtered_dataset <- MAEFilteredDataset$new(dataset = miniACC, dataname = "miniacc")
   fs <- teal_slices(

--- a/tests/testthat/test-SEFilterStates.R
+++ b/tests/testthat/test-SEFilterStates.R
@@ -36,6 +36,7 @@ get_test_data <- function(no_data = FALSE) {
 
 # initialize ----
 testthat::test_that("constructor accepts a SummarizedExperiment", {
+  testthat::skip_if_not_installed("SummarizedExperiment")
   testthat::expect_no_error(SEFilterStates$new(data = get_test_data(), dataname = "test"))
   testthat::expect_error(
     SEFilterStates$new(data = iris, dataname = "test"),
@@ -45,6 +46,7 @@ testthat::test_that("constructor accepts a SummarizedExperiment", {
 
 # set_filter_state ----
 testthat::test_that("set_filter_state only accepts `teal_slices`", {
+  testthat::skip_if_not_installed("SummarizedExperiment")
   filter_states <- SEFilterStates$new(data = get_test_data(), dataname = "test")
   fs <- teal_slices()
   testthat::expect_error(
@@ -55,6 +57,7 @@ testthat::test_that("set_filter_state only accepts `teal_slices`", {
 })
 
 testthat::test_that("set_filter_state arg - ", {
+  testthat::skip_if_not_installed("SummarizedExperiment")
   filter_states <- SEFilterStates$new(data = get_test_data(), dataname = "test")
   fs <- teal_slices(
     teal_slice(dataname = "test", varname = "feature_id", selected = c("ID001", "ID002"), arg = "subset"),
@@ -69,6 +72,7 @@ testthat::test_that("set_filter_state arg - ", {
 
 # get_call ----
 testthat::test_that("get_call returns executable subset call ", {
+  testthat::skip_if_not_installed("SummarizedExperiment")
   test <- get_test_data()
   filter_states <- SEFilterStates$new(data = test, dataname = "test")
   fs <- teal_slices(
@@ -96,6 +100,7 @@ testthat::test_that("get_call returns executable subset call ", {
 
 # ui_add ----
 testthat::test_that("ui_add returns a message inside a div when data has no rows or no columns", {
+  testthat::skip_if_not_installed("SummarizedExperiment")
   filter_states <- SEFilterStates$new(data = get_test_data(TRUE)[[1]], dataname = "test")
   testthat::expect_identical(
     filter_states$ui_add("id"),

--- a/tests/testthat/test-filter_panel_api.R
+++ b/tests/testthat/test-filter_panel_api.R
@@ -123,6 +123,7 @@ testthat::test_that("FilterPanelAPI$clear_filter_states remove the filters of th
 # WRAPPER FUNCTIONS ----
 # get_filter_state ----
 testthat::test_that("get_filter_state returns `teal_slices` with features identical to those in input", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   datasets <- init_filtered_data(
     x = list(
@@ -170,6 +171,7 @@ testthat::test_that("get_filter_state returns `teal_slices` with features identi
 
 # remove_filter_state ----
 testthat::test_that("remove_filter_state removes filter state specified by `teal_slices`", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   datasets <- init_filtered_data(
     x = list(
@@ -197,6 +199,7 @@ testthat::test_that("remove_filter_state removes filter state specified by `teal
 
 # clear_filter_states ----
 testthat::test_that("clear_filter_states removes all filter states", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data(miniACC, package = "MultiAssayExperiment")
   datasets <- init_filtered_data(
     x = list(

--- a/tests/testthat/test-init_filter_states.R
+++ b/tests/testthat/test-init_filter_states.R
@@ -17,6 +17,7 @@ testthat::test_that("init_filter_states returns a MatrixFilterStates object if p
 })
 
 testthat::test_that("init_filter_states returns an MAEFilterStates object if passed an object of class MAE", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   mock_mae <- structure(list(), class = "MultiAssayExperiment")
   testthat::expect_no_error(
     filter_states <- init_filter_states(mock_mae, dataname = "test")
@@ -25,6 +26,7 @@ testthat::test_that("init_filter_states returns an MAEFilterStates object if pas
 })
 
 testthat::test_that("init_filter_states returns an SEFilterStates object if passed an object of class SE", {
+  testthat::skip_if_not_installed("SummarizedExperiment")
   mock_se <- structure(list(), class = "SummarizedExperiment")
   testthat::expect_no_error(
     filter_states <- init_filter_states(

--- a/tests/testthat/test-init_filtered_dataset.R
+++ b/tests/testthat/test-init_filtered_dataset.R
@@ -6,6 +6,7 @@ testthat::test_that("init_filtered_dataset returns a DataframeFilteredDataset wh
 })
 
 testthat::test_that("init_filtered_dataset returns an MAEFilteredDataset when passed an MAE", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
   utils::data("miniACC", package = "MultiAssayExperiment")
 
   testthat::expect_no_error(filtered_dataset <- init_filtered_dataset(

--- a/tests/testthat/test-teal_slice.R
+++ b/tests/testthat/test-teal_slice.R
@@ -223,6 +223,7 @@ testthat::test_that("teal_slice dataname has to be a string when expr is specifi
 testthat::test_that(
   "teal_slice converts factors to characters for 'selected' and 'choices' parameters",
   {
+    testthat::skip_if_not_installed("withr")
     slices_path <- withr::local_file("slices.json")
     tss <- teal_slices(
       teal_slice(


### PR DESCRIPTION
- Part of pre-release activities #506 (base branch for this PR is `pre-release-cleanup@main`)
- Rationale on https://github.com/insightsengineering/idr-tasks/issues/713

### Changes description

- [x] Handles `@examples`
  - with `@examplesIf requireNamespace("MultiAssayExperiment")` as suggested [here](https://indrajeetpatil.github.io/preventive-r-package-care/#/soft-dependency-hygiene)
  - Conditional clause replacing `miniACC` with empty data.frame
- [x] Skips tests that use {MAE} or {SE}
- [x] Skips tests that use {withr}

#### Discussions

- > That's not a reason to skip tests. MAE is in Suggests so installing is the responsibility of the person who wants to run tests, i.e. not the end user. If someone uses teal with MAE data, they most likely have the package installed.
- Some generic tests and examples for `filter_state_api` are complex cases that join together normal data frames with MAE
    - These could be broken down to 2 examples.
- If we merge this it also means tests using {withr} should be skipped
  - Seems silly, but necessary to be a complete compliance

WDYT?