### PR TITLE
516 `topological_sort`

### DIFF
--- a/R/FilteredData-utils.R
+++ b/R/FilteredData-utils.R
@@ -142,48 +142,5 @@ toggle_title <- function(input_id, titles, one_way = FALSE) {
 #' @seealso examples found here: `vignette("internal_function_examples", package = "teal.slice")`.
 #' @keywords internal
 topological_sort <- function(graph) {
-  # compute in-degrees
-  in_degrees <- list()
-  for (node in names(graph)) {
-    in_degrees[[node]] <- 0
-    for (to_edge in graph[[node]]) {
-      in_degrees[[to_edge]] <- 0
-    }
-  }
-
-  for (node in graph) {
-    for (to_edge in node) {
-      in_degrees[[to_edge]] <- in_degrees[[to_edge]] + 1
-    }
-  }
-
-  # sort
-  visited <- 0
-  sorted <- list()
-  zero_in <- list()
-  for (node in names(in_degrees)) {
-    if (in_degrees[[node]] == 0) zero_in <- append(zero_in, node)
-  }
-  zero_in <- rev(zero_in)
-
-  while (length(zero_in) != 0) {
-    visited <- visited + 1
-    sorted <- c(zero_in[[1]], sorted)
-    for (edge_to in graph[[zero_in[[1]]]]) {
-      in_degrees[[edge_to]] <- in_degrees[[edge_to]] - 1
-      if (in_degrees[[edge_to]] == 0) {
-        zero_in <- append(zero_in, edge_to, 1)
-      }
-    }
-    zero_in[[1]] <- NULL
-  }
-
-  if (visited != length(in_degrees)) {
-    stop(
-      "Graph is not a directed acyclic graph. Cycles involving nodes: ",
-      paste0(setdiff(names(in_degrees), sorted), collapse = " ")
-    )
-  } else {
-    return(sorted)
-  }
+  utils::getFromNamespace("topological_sort", ns = "teal.data")(graph)
 }


### PR DESCRIPTION
Fixes #516 

Replaced function definition for `topological_sort` with wrapper for the same function defined in `teal.data`.
The new definition remains in `FilteredData-utils.R` to maintain documentation (would be too much to put i `zzz.R`).