### PR TITLE
Enables `indentation_linter` rule

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,5 @@
 linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
   cyclocomp_linter = NULL,
-  object_usage_linter = NULL,
-  indentation_linter = NULL
+  object_usage_linter = NULL
   )

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -240,8 +240,10 @@ DatetimeFilterState <- R6::R6Class( # nolint
 
       private$set_is_choice_limited(private$x, choices)
       private$x <- private$x[
-        (as.POSIXct(trunc(private$x, units = "secs")) >= choices[1L] &
-          as.POSIXct(trunc(private$x, units = "secs")) <= choices[2L]) | is.na(private$x)
+        (
+          as.POSIXct(trunc(private$x, units = "secs")) >= choices[1L] &
+            as.POSIXct(trunc(private$x, units = "secs")) <= choices[2L]
+        ) | is.na(private$x)
       ]
       private$teal_slice$choices <- choices
       invisible(NULL)

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -215,8 +215,10 @@ LogicalFilterState <- R6::R6Class( # nolint
         TRUE
       } else if (all(private$choices_counts > 0)) {
         TRUE
-      } else if (setequal(private$get_selected(), private$get_choices()) &&
-        !anyNA(private$get_selected(), private$get_choices())) {
+      } else if (
+        setequal(private$get_selected(), private$get_choices()) &&
+          !anyNA(private$get_selected(), private$get_choices())
+      ) {
         TRUE
       } else if (!isTRUE(private$get_keep_na()) && private$na_count > 0) {
         TRUE

--- a/tests/testthat/test-DatetimeFilterState.R
+++ b/tests/testthat/test-DatetimeFilterState.R
@@ -237,9 +237,13 @@ testthat::test_that("get_call returns call if all selected but NA exists", {
   )
   testthat::expect_equal(
     shiny::isolate(filter_state$get_call()),
-    quote(!is.na(variable) &
-      (variable >= as.POSIXct("2000-01-01 12:00:00", tz = "GMT") &
-        variable < as.POSIXct("2000-01-01 12:00:10", tz = "GMT")))
+    quote(
+      !is.na(variable) &
+        (
+          variable >= as.POSIXct("2000-01-01 12:00:00", tz = "GMT") &
+            variable < as.POSIXct("2000-01-01 12:00:10", tz = "GMT")
+        )
+    )
   )
 })
 

--- a/tests/testthat/test-FilterStates.R
+++ b/tests/testthat/test-FilterStates.R
@@ -62,35 +62,46 @@ testthat::test_that("set_filter_state and get_filter_state, sets and returns the
   expect_identical_slices(filter_states$get_filter_state(), fs)
 })
 
-testthat::test_that("set_filter_state updates FilterState when dataname and varname are matched between teal_slice and
-existing filter", {
-  filter_states <- FilterStates$new(data = data.frame(a = 1:10), dataname = "test")
-  fs <- teal_slices(
-    teal_slice(
-      dataname = "test", varname = "a", choices = c(1, 5), selected = c(1, 4), keep_na = FALSE, keep_inf = FALSE,
-      fixed = FALSE, anchored = FALSE, any_attribute = "a", another_attribute = "b"
-    ),
-    count_type = "none"
-  )
-  filter_states$set_filter_state(fs)
-  fs[[1]]$selected <- c(1, 5)
-  filter_states$set_filter_state(fs)
-  expect_identical_slices(filter_states$get_filter_state(), fs)
-})
+testthat::test_that(
+  paste(
+    "set_filter_state",
+    "updates FilterState when dataname and varname are matched between teal_slice and existing filter"
+  ),
+  {
+    filter_states <- FilterStates$new(data = data.frame(a = 1:10), dataname = "test")
+    fs <- teal_slices(
+      teal_slice(
+        dataname = "test", varname = "a", choices = c(1, 5), selected = c(1, 4), keep_na = FALSE, keep_inf = FALSE,
+        fixed = FALSE, anchored = FALSE, any_attribute = "a", another_attribute = "b"
+      ),
+      count_type = "none"
+    )
+    filter_states$set_filter_state(fs)
+    fs[[1]]$selected <- c(1, 5)
+    filter_states$set_filter_state(fs)
+    expect_identical_slices(filter_states$get_filter_state(), fs)
+  }
+)
 
-testthat::test_that("set_filter_state allows to create two filters on the same variable if combination of their
-fields (dataname, varname, varlabel, arg, id) differ", {
-  filter_states <- FilterStates$new(data = data.frame(a = 1:10), dataname = "a")
-  fs <- teal_slices(
-    teal_slice(dataname = "a", varname = "a"),
-    teal_slice(dataname = "a", varname = "a", experiment = "a"),
-    teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a"),
-    teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a"),
-    count_type = "none"
-  )
-  filter_states$set_filter_state(fs)
-  testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 4)
-})
+testthat::test_that(
+  paste(
+    "set_filter_state",
+    "allows to create two filters on the same variable if combination of their",
+    "fields (dataname, varname, varlabel, arg, id) differ"
+  ),
+  {
+    filter_states <- FilterStates$new(data = data.frame(a = 1:10), dataname = "a")
+    fs <- teal_slices(
+      teal_slice(dataname = "a", varname = "a"),
+      teal_slice(dataname = "a", varname = "a", experiment = "a"),
+      teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a"),
+      teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a"),
+      count_type = "none"
+    )
+    filter_states$set_filter_state(fs)
+    testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 4)
+  }
+)
 
 
 testthat::test_that("set_filter_state creates a new FilterStateExpr", {
@@ -144,36 +155,41 @@ testthat::test_that("remove_filter_state of inexistent FilterState raiser warnin
   )
 })
 
-testthat::test_that("remove_filter_state removes FilterState objects identified by 'dataname', 'experiment',
-'varname', 'arg' and/or 'id'", {
-  filter_states <- FilterStates$new(data = data.frame(a = 1:5), dataname = "a")
-  fs <- teal_slices(
-    teal_slice(dataname = "a", varname = "a"),
-    teal_slice(dataname = "a", varname = "a", experiment = "a"),
-    teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a"),
-    teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a"),
-    count_type = "none"
-  )
-  filter_states$set_filter_state(fs)
+testthat::test_that(
+  paste(
+    "remove_filter_state",
+    "removes FilterState objects identified by 'dataname', 'experiment', 'varname', 'arg' and/or 'id'"
+  ),
+  {
+    filter_states <- FilterStates$new(data = data.frame(a = 1:5), dataname = "a")
+    fs <- teal_slices(
+      teal_slice(dataname = "a", varname = "a"),
+      teal_slice(dataname = "a", varname = "a", experiment = "a"),
+      teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a"),
+      teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a"),
+      count_type = "none"
+    )
+    filter_states$set_filter_state(fs)
 
-  filter_states$remove_filter_state(teal_slices(teal_slice(dataname = "a", varname = "a")))
-  testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 3)
+    filter_states$remove_filter_state(teal_slices(teal_slice(dataname = "a", varname = "a")))
+    testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 3)
 
-  filter_states$remove_filter_state(teal_slices(
-    teal_slice(dataname = "a", varname = "a", experiment = "a")
-  ))
-  testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 2)
+    filter_states$remove_filter_state(teal_slices(
+      teal_slice(dataname = "a", varname = "a", experiment = "a")
+    ))
+    testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 2)
 
-  filter_states$remove_filter_state(teal_slices(
-    teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a")
-  ))
-  testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 1)
+    filter_states$remove_filter_state(teal_slices(
+      teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a")
+    ))
+    testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 1)
 
-  filter_states$remove_filter_state(teal_slices(
-    teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a")
-  ))
-  testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 0)
-})
+    filter_states$remove_filter_state(teal_slices(
+      teal_slice(dataname = "a", varname = "a", experiment = "a", arg = "a", id = "a")
+    ))
+    testthat::expect_length(shiny::isolate(filter_states$get_filter_state()), 0)
+  }
+)
 
 testthat::test_that("clearing empty `FilterStates` does not raise errors", {
   filter_states <- FilterStates$new(data = NULL, dataname = "test")

--- a/tests/testthat/test-init_filter_state.R
+++ b/tests/testthat/test-init_filter_state.R
@@ -49,37 +49,45 @@ testthat::test_that("init_filter_state returns a DateFilterState object if passe
   )
 })
 
-testthat::test_that("init_filter_state returns a ChoicesFilterState object if passed
-  a POSIXct or POSIXlt of length 1", {
-  dates <- seq(as.Date("1990/01/01"), by = 1, length.out = 1)
-  testthat::expect_s3_class(
-    init_filter_state(as.POSIXct(dates), slice = teal_slice(dataname = "data", varname = "var")), "ChoicesFilterState"
-  )
-  testthat::expect_s3_class(
-    init_filter_state(as.POSIXlt(dates), slice = teal_slice(dataname = "data", varname = "var")), "ChoicesFilterState"
-  )
-})
+testthat::test_that(
+  "init_filter_state returns a ChoicesFilterState object if passed a POSIXct or POSIXlt of length 1",
+  {
+    dates <- seq(as.Date("1990/01/01"), by = 1, length.out = 1)
+    testthat::expect_s3_class(
+      init_filter_state(as.POSIXct(dates), slice = teal_slice(dataname = "data", varname = "var")), "ChoicesFilterState"
+    )
+    testthat::expect_s3_class(
+      init_filter_state(as.POSIXlt(dates), slice = teal_slice(dataname = "data", varname = "var")), "ChoicesFilterState"
+    )
+  }
+)
 
-testthat::test_that("init_filter_state returns a DatetimeFilterState object if passed
-  a longer POSIXct or POSIXlt", {
-  dates <- seq(as.Date("1990/01/01"), by = 1, length.out = getOption("teal.threshold_slider_vs_checkboxgroup") + 1)
-  testthat::expect_s3_class(
-    init_filter_state(as.POSIXct(dates), slice = teal_slice(dataname = "data", varname = "var")), "DatetimeFilterState"
-  )
-  testthat::expect_s3_class(
-    init_filter_state(as.POSIXlt(dates), slice = teal_slice(dataname = "data", varname = "var")), "DatetimeFilterState"
-  )
-})
+testthat::test_that(
+  "init_filter_state returns a DatetimeFilterState object if passed a longer POSIXct or POSIXlt",
+  {
+    dates <- seq(as.Date("1990/01/01"), by = 1, length.out = getOption("teal.threshold_slider_vs_checkboxgroup") + 1)
+    testthat::expect_s3_class(
+      init_filter_state(as.POSIXct(dates), slice = teal_slice(dataname = "data", varname = "var")),
+      "DatetimeFilterState"
+    )
+    testthat::expect_s3_class(
+      init_filter_state(as.POSIXlt(dates), slice = teal_slice(dataname = "data", varname = "var")),
+      "DatetimeFilterState"
+    )
+  }
+)
 
 testthat::test_that("init_filter_state returns a RangeFilterState if passed a numeric vector containing Inf", {
   testthat::expect_s3_class(
-    init_filter_state(c(1, 2, 3, 4, Inf), slice = teal_slice(dataname = "data", varname = "var")), "RangeFilterState"
+    init_filter_state(c(1, 2, 3, 4, Inf), slice = teal_slice(dataname = "data", varname = "var")),
+    "RangeFilterState"
   )
 })
 
 testthat::test_that("init_filter_state returns a ChoicesFilterState if passed fewer than five non-NA elements", {
   testthat::expect_s3_class(
-    init_filter_state(c(1, 2, 3, 4, NA), slice = teal_slice(dataname = "data", varname = "var")), "ChoicesFilterState"
+    init_filter_state(c(1, 2, 3, 4, NA), slice = teal_slice(dataname = "data", varname = "var")),
+    "ChoicesFilterState"
   )
 })
 


### PR DESCRIPTION
Part of pre-release activities (from [this conversation](https://github.com/insightsengineering/teal.slice/pull/506#discussion_r1453278407))

It's also possible to remove disable of `cyclocomp_linter = NULL` (cyclomatic complexity), but this is out of scope as it is disabled in all repos of teal

#### Changes description

* Reflows code in a coding style that is left unchanged by {styler} and doesn't raise error in {lintr}