### PR TITLE
`ui` to UI in documentation

### DIFF
--- a/R/FilterPanelAPI.R
+++ b/R/FilterPanelAPI.R
@@ -5,14 +5,16 @@
 #'
 #' @title Class to encapsulate the API of the filter panel of a teal app
 #'
-#' @description An API class for managing filter states in a teal application's filter panel.
+#' @description
+#' An API class for managing filter states in a teal application's filter panel.
 #'
 #' @details
-#'   The purpose of this class is to encapsulate the API of the filter panel in a new class `FilterPanelAPI` so
-#'   that it can be passed and used in the `server` call of any module instead of passing the whole `FilteredData`
-#'   object.
+#' The purpose of this class is to encapsulate the API of the filter panel in a
+#' new class `FilterPanelAPI` so that it can be passed and used in the server
+#' call of any module instead of passing the whole `FilteredData` object.
 #'
-#'   This class is supported by methods to set, get, remove filter states in the filter panel API.
+#' This class is supported by methods to set, get, remove filter states in the
+#' filter panel API.
 #'
 #' @examples
 #' library(teal.slice)

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -25,7 +25,7 @@
 #' Each variable's filter state is an `R6` object which contains `choices`,
 #' `selected`, `varname`, `dataname`, `labels`, `na_count`, `keep_na` and other
 #' variable type specific fields (`keep_inf`, `inf_count`, `timezone`).
-#' Object contains also shiny module (`ui` and `server`) which manages
+#' Object also contains a shiny module (UI and server) which manages the
 #' state of the filter through reactive values `selected`, `keep_na`, `keep_inf`
 #' which trigger `get_call()` and every `R` function call up in reactive chain.
 #'
@@ -280,11 +280,11 @@ FilterState <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' Shiny module `ui`.
+    #' Shiny UI module.
     #'
     #' @param id (`character(1)`)
     #'  shiny element (module instance) id;
-    #'  the `ui` for this class contains simple message stating that it is not supported
+    #'  the UI for this class contains simple message stating that it is not supported
     #' @param parent_id (`character(1)`) id of the `FilterStates` card container
     ui = function(id, parent_id = "cards") {
       ns <- NS(id)

--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -177,11 +177,11 @@ FilterStateExpr <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' Shiny module `ui`.
+    #' Shiny module UI.
     #'
     #' @param id (`character(1)`)
     #'  shiny element (module instance) id;
-    #'  the `ui` for this class contains simple message stating that it is not supported
+    #'  the UI for this class contains simple message stating that it is not supported
     #' @param parent_id (`character(1)`) id of the `FilterStates` card container
     ui = function(id, parent_id = "cards") {
       ns <- NS(id)

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -192,7 +192,7 @@ FilterStates <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' Remove one or more `FilterState`s from the `state_list` along with their `ui` elements.
+    #' Remove one or more `FilterState`s from the `state_list` along with their UI elements.
     #'
     #' @param state (`teal_slices`)
     #'   specifying `FilterState` objects to remove;
@@ -305,7 +305,7 @@ FilterStates <- R6::R6Class( # nolint
     # shiny modules ----
 
     #' @description
-    #' Shiny `ui` element that stores `FilterState` `ui` elements.
+    #' Shiny UI definition that stores `FilterState` UI elements.
     #' Populated with elements created with `renderUI` in the module server.
     #'
     #' @param id (`character(1)`)
@@ -396,7 +396,7 @@ FilterStates <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' Shiny `ui` module to add filter variable.
+    #' Shiny UI module to add filter variable.
     #'
     #' @param id (`character(1)`)
     #'  shiny element (module instance) id
@@ -426,7 +426,7 @@ FilterStates <- R6::R6Class( # nolint
     #' Removing a filter variable adds it back to available choices.
     #'
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's `ui_add` function.
     #'
     #' @return `moduleServer` function which returns `NULL`
     srv_add = function(id) {

--- a/R/FilterStatesSE.R
+++ b/R/FilterStatesSE.R
@@ -93,7 +93,7 @@ SEFilterStates <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' Shiny `ui` module to add filter variable.
+    #' Shiny UI module to add filter variable.
     #' @param id (`character(1)`)
     #'  id of shiny module
     #' @return `shiny.tag`
@@ -148,7 +148,7 @@ SEFilterStates <- R6::R6Class( # nolint
     #' `rowData`.
     #'
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's `ui_add` function.
     #' @return `moduleServer` function which returns `NULL`
     srv_add = function(id) {
       data <- private$data

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -516,7 +516,8 @@ FilteredData <- R6::R6Class( # nolint
     #' Server function for filter panel.
     #'
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's
+    #'   `ui_filter_panel` function.
     #' @param active_datanames (`function` or `reactive`) returning `datanames` that
     #'   should be shown on the filter panel,
     #'   must be a subset of the `datanames` argument provided to `ui_filter_panel`;
@@ -550,7 +551,7 @@ FilteredData <- R6::R6Class( # nolint
     #' @description
     #' Server module responsible for displaying active filters.
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's `srv_active` function.
     #' @return `shiny.tag`
     ui_active = function(id) {
       ns <- NS(id)
@@ -600,7 +601,7 @@ FilteredData <- R6::R6Class( # nolint
     #' @description
     #' Server module responsible for displaying active filters.
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's `ui_active` function.
     #' @param active_datanames (`reactive`)
     #'   defining subset of `self$datanames()` to be displayed.
     #' @return `moduleServer` returning `NULL`
@@ -669,7 +670,8 @@ FilteredData <- R6::R6Class( # nolint
     #' @description
     #' Server module responsible for displaying drop-downs with variables to add a filter.
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's
+    #'   `ui_add` function.
     #' @return `shiny.tag`
     ui_add = function(id) {
       ns <- NS(id)
@@ -711,7 +713,8 @@ FilteredData <- R6::R6Class( # nolint
     #' @description
     #' Server module responsible for displaying drop-downs with variables to add a filter.
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's
+    #'   `ui_add` function.
     #' @param active_datanames (`reactive`)
     #'   defining subset of `self$datanames()` to be displayed.
     #' @return `moduleServer` returning `NULL`
@@ -750,7 +753,7 @@ FilteredData <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' Creates the `ui` for the module showing counts for each dataset
+    #' Creates the UI definition for the module showing counts for each dataset
     #' contrasting the filtered to the full unfiltered dataset.
     #'
     #' Per dataset, it displays
@@ -795,7 +798,8 @@ FilteredData <- R6::R6Class( # nolint
     #' data.
     #'
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's
+    #'   `ui_overview` function.
     #' @param active_datanames (`reactive`)
     #'   returning `datanames` that should be shown on the filter panel,
     #'   must be a subset of the `datanames` argument provided to `ui_filter_panel`;

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -214,14 +214,14 @@ FilteredDataset <- R6::R6Class( # nolint
 
     # modules ------
     #' @description
-    #' `ui` module for dataset active filters.
+    #' UI module for dataset active filters.
     #' @details
-    #' `ui` module containing dataset active filters along with
+    #' UI module containing dataset active filters along with
     #' title and remove button.
     #' @param id (`character(1)`)
     #'  identifier of the element - preferably containing dataset name
     #'
-    #' @return function - shiny `ui` module
+    #' @return function - shiny UI module
     ui_active = function(id) {
       dataname <- self$get_dataname()
       checkmate::assert_string(dataname)
@@ -287,7 +287,7 @@ FilteredDataset <- R6::R6Class( # nolint
     #' Server module for a dataset active filters.
     #'
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's `ui_active` function.
     #' @return `moduleServer` function which returns `NULL`
     srv_active = function(id) {
       moduleServer(
@@ -338,12 +338,12 @@ FilteredDataset <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' `ui` module to add filter variable for this dataset.
+    #' UI module to add filter variable for this dataset.
     #'
     #' @param id (`character(1)`)
     #'  identifier of the element - preferably containing dataset name
     #'
-    #' @return function - shiny `ui` module
+    #' @return function - shiny UI module
     ui_add = function(id) {
       stop("Pure virtual method")
     },
@@ -356,7 +356,8 @@ FilteredDataset <- R6::R6Class( # nolint
     #' experiment.
     #'
     #' @param id (`character(1)`)
-    #'   an id string that corresponds with the id used to call the module's `ui` function.
+    #'   an id string that corresponds with the id used to call the module's
+    #'   `ui_add` function.
     #'
     #' @return `moduleServer` function which returns `NULL`
     #'

--- a/R/FilteredDatasetDataframe.R
+++ b/R/FilteredDatasetDataframe.R
@@ -220,12 +220,12 @@ DataframeFilteredDataset <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' `ui` module to add filter variable for this dataset.
+    #' UI module to add filter variable for this dataset.
     #'
     #' @param id (`character(1)`)
     #'  identifier of the element - preferably containing dataset name
     #'
-    #' @return function - shiny `ui` module
+    #' @return function - shiny UI module
     ui_add = function(id) {
       ns <- NS(id)
       tagList(

--- a/R/FilteredDatasetDefault.R
+++ b/R/FilteredDatasetDefault.R
@@ -86,7 +86,7 @@ DefaultFilteredDataset <- R6::R6Class( # nolint
     #' @description
     #' Overwrites parent method.
     #' @details
-    #' Blank module `ui` that would list active filter states for this dataset.
+    #' Blank UI module that would list active filter states for this dataset.
     #' @param id (`character(1)`)
     #'  `shiny` module id
     #' @return empty `div`
@@ -98,7 +98,7 @@ DefaultFilteredDataset <- R6::R6Class( # nolint
     #' @description
     #' Overwrites parent method.
     #' @details
-    #' Blank module `ui` that would list active filter states for this dataset.
+    #' Blank UI module that would list active filter states for this dataset.
     #' @param id (`character(1)`)
     #'  `shiny` module id
     #' @return empty `div`

--- a/R/FilteredDatasetMAE.R
+++ b/R/FilteredDatasetMAE.R
@@ -172,11 +172,11 @@ MAEFilteredDataset <- R6::R6Class( # nolint
     },
 
     #' @description
-    #' `ui` module to add filter variable for this dataset.
+    #' UI module to add filter variable for this dataset.
     #' @param id (`character(1)`)
     #'  identifier of the element - preferably containing dataset name
     #'
-    #' @return function - shiny `ui` module
+    #' @return function - shiny UI module
     #'
     ui_add = function(id) {
       ns <- NS(id)

--- a/man/DataframeFilteredDataset.Rd
+++ b/man/DataframeFilteredDataset.Rd
@@ -189,7 +189,7 @@ specifying \code{FilterState} objects to remove;
 \if{html}{\out{<a id="method-DataframeFilteredDataset-ui_add"></a>}}
 \if{latex}{\out{\hypertarget{method-DataframeFilteredDataset-ui_add}{}}}
 \subsection{Method \code{ui_add()}}{
-\code{ui} module to add filter variable for this dataset.
+UI module to add filter variable for this dataset.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DataframeFilteredDataset$ui_add(id)}\if{html}{\out{</div>}}
 }
@@ -203,7 +203,7 @@ identifier of the element - preferably containing dataset name}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-function - shiny \code{ui} module
+function - shiny UI module
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/DefaultFilteredDataset.Rd
+++ b/man/DefaultFilteredDataset.Rd
@@ -194,7 +194,7 @@ Overwrites parent method.
 \if{html}{\out{</div>}}
 }
 \subsection{Details}{
-Blank module \code{ui} that would list active filter states for this dataset.
+Blank UI module that would list active filter states for this dataset.
 }
 
 \subsection{Returns}{
@@ -219,7 +219,7 @@ Overwrites parent method.
 \if{html}{\out{</div>}}
 }
 \subsection{Details}{
-Blank module \code{ui} that would list active filter states for this dataset.
+Blank UI module that would list active filter states for this dataset.
 }
 
 \subsection{Returns}{

--- a/man/FilterPanelAPI.Rd
+++ b/man/FilterPanelAPI.Rd
@@ -8,11 +8,12 @@
 An API class for managing filter states in a teal application's filter panel.
 }
 \details{
-The purpose of this class is to encapsulate the API of the filter panel in a new class \code{FilterPanelAPI} so
-that it can be passed and used in the \code{server} call of any module instead of passing the whole \code{FilteredData}
-object.
+The purpose of this class is to encapsulate the API of the filter panel in a
+new class \code{FilterPanelAPI} so that it can be passed and used in the server
+call of any module instead of passing the whole \code{FilteredData} object.
 
-This class is supported by methods to set, get, remove filter states in the filter panel API.
+This class is supported by methods to set, get, remove filter states in the
+filter panel API.
 }
 \examples{
 library(teal.slice)

--- a/man/FilterState.Rd
+++ b/man/FilterState.Rd
@@ -27,7 +27,7 @@ code relevant to selected values.
 Each variable's filter state is an \code{R6} object which contains \code{choices},
 \code{selected}, \code{varname}, \code{dataname}, \code{labels}, \code{na_count}, \code{keep_na} and other
 variable type specific fields (\code{keep_inf}, \code{inf_count}, \code{timezone}).
-Object contains also shiny module (\code{ui} and \code{server}) which manages
+Object also contains a shiny module (UI and server) which manages the
 state of the filter through reactive values \code{selected}, \code{keep_na}, \code{keep_inf}
 which trigger \code{get_call()} and every \code{R} function call up in reactive chain.
 }
@@ -220,7 +220,7 @@ signaling that remove button has been clicked
 \if{html}{\out{<a id="method-FilterState-ui"></a>}}
 \if{latex}{\out{\hypertarget{method-FilterState-ui}{}}}
 \subsection{Method \code{ui()}}{
-Shiny module \code{ui}.
+Shiny UI module.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilterState$ui(id, parent_id = "cards")}\if{html}{\out{</div>}}
 }
@@ -230,7 +230,7 @@ Shiny module \code{ui}.
 \describe{
 \item{\code{id}}{(\code{character(1)})
 shiny element (module instance) id;
-the \code{ui} for this class contains simple message stating that it is not supported}
+the UI for this class contains simple message stating that it is not supported}
 
 \item{\code{parent_id}}{(\code{character(1)}) id of the \code{FilterStates} card container}
 }

--- a/man/FilterStateExpr.Rd
+++ b/man/FilterStateExpr.Rd
@@ -232,7 +232,7 @@ signaling that remove button has been clicked
 \if{html}{\out{<a id="method-FilterStateExpr-ui"></a>}}
 \if{latex}{\out{\hypertarget{method-FilterStateExpr-ui}{}}}
 \subsection{Method \code{ui()}}{
-Shiny module \code{ui}.
+Shiny module UI.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilterStateExpr$ui(id, parent_id = "cards")}\if{html}{\out{</div>}}
 }
@@ -242,7 +242,7 @@ Shiny module \code{ui}.
 \describe{
 \item{\code{id}}{(\code{character(1)})
 shiny element (module instance) id;
-the \code{ui} for this class contains simple message stating that it is not supported}
+the UI for this class contains simple message stating that it is not supported}
 
 \item{\code{parent_id}}{(\code{character(1)}) id of the \code{FilterStates} card container}
 }

--- a/man/FilterStates.Rd
+++ b/man/FilterStates.Rd
@@ -177,7 +177,7 @@ Prints this \code{FilterStates} object.
 \if{html}{\out{<a id="method-FilterStates-remove_filter_state"></a>}}
 \if{latex}{\out{\hypertarget{method-FilterStates-remove_filter_state}{}}}
 \subsection{Method \code{remove_filter_state()}}{
-Remove one or more \code{FilterState}s from the \code{state_list} along with their \code{ui} elements.
+Remove one or more \code{FilterState}s from the \code{state_list} along with their UI elements.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilterStates$remove_filter_state(state)}\if{html}{\out{</div>}}
 }
@@ -259,7 +259,7 @@ include locked filter states}
 \if{html}{\out{<a id="method-FilterStates-ui_active"></a>}}
 \if{latex}{\out{\hypertarget{method-FilterStates-ui_active}{}}}
 \subsection{Method \code{ui_active()}}{
-Shiny \code{ui} element that stores \code{FilterState} \code{ui} elements.
+Shiny UI definition that stores \code{FilterState} UI elements.
 Populated with elements created with \code{renderUI} in the module server.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilterStates$ui_active(id)}\if{html}{\out{</div>}}
@@ -302,7 +302,7 @@ shiny module instance id}
 \if{html}{\out{<a id="method-FilterStates-ui_add"></a>}}
 \if{latex}{\out{\hypertarget{method-FilterStates-ui_add}{}}}
 \subsection{Method \code{ui_add()}}{
-Shiny \code{ui} module to add filter variable.
+Shiny UI module to add filter variable.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilterStates$ui_add(id)}\if{html}{\out{</div>}}
 }
@@ -336,7 +336,7 @@ Removing a filter variable adds it back to available choices.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's \code{ui_add} function.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -556,7 +556,8 @@ Server function for filter panel.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's
+\code{ui_filter_panel} function.}
 
 \item{\code{active_datanames}}{(\code{function} or \code{reactive}) returning \code{datanames} that
 should be shown on the filter panel,
@@ -583,7 +584,7 @@ Server module responsible for displaying active filters.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's \code{srv_active} function.}
 }
 \if{html}{\out{</div>}}
 }
@@ -604,7 +605,7 @@ Server module responsible for displaying active filters.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's \code{ui_active} function.}
 
 \item{\code{active_datanames}}{(\code{reactive})
 defining subset of \code{self$datanames()} to be displayed.}
@@ -628,7 +629,8 @@ Server module responsible for displaying drop-downs with variables to add a filt
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's
+\code{ui_add} function.}
 }
 \if{html}{\out{</div>}}
 }
@@ -649,7 +651,8 @@ Server module responsible for displaying drop-downs with variables to add a filt
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's
+\code{ui_add} function.}
 
 \item{\code{active_datanames}}{(\code{reactive})
 defining subset of \code{self$datanames()} to be displayed.}
@@ -664,7 +667,7 @@ defining subset of \code{self$datanames()} to be displayed.}
 \if{html}{\out{<a id="method-FilteredData-ui_overview"></a>}}
 \if{latex}{\out{\hypertarget{method-FilteredData-ui_overview}{}}}
 \subsection{Method \code{ui_overview()}}{
-Creates the \code{ui} for the module showing counts for each dataset
+Creates the UI definition for the module showing counts for each dataset
 contrasting the filtered to the full unfiltered dataset.
 
 Per dataset, it displays
@@ -696,7 +699,8 @@ data.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's
+\code{ui_overview} function.}
 
 \item{\code{active_datanames}}{(\code{reactive})
 returning \code{datanames} that should be shown on the filter panel,

--- a/man/FilteredDataset.Rd
+++ b/man/FilteredDataset.Rd
@@ -287,7 +287,7 @@ Gets the dataset label.
 \if{html}{\out{<a id="method-FilteredDataset-ui_active"></a>}}
 \if{latex}{\out{\hypertarget{method-FilteredDataset-ui_active}{}}}
 \subsection{Method \code{ui_active()}}{
-\code{ui} module for dataset active filters.
+UI module for dataset active filters.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$ui_active(id)}\if{html}{\out{</div>}}
 }
@@ -301,12 +301,12 @@ identifier of the element - preferably containing dataset name}
 \if{html}{\out{</div>}}
 }
 \subsection{Details}{
-\code{ui} module containing dataset active filters along with
+UI module containing dataset active filters along with
 title and remove button.
 }
 
 \subsection{Returns}{
-function - shiny \code{ui} module
+function - shiny UI module
 }
 }
 \if{html}{\out{<hr>}}
@@ -322,7 +322,7 @@ Server module for a dataset active filters.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's \code{ui_active} function.}
 }
 \if{html}{\out{</div>}}
 }
@@ -334,7 +334,7 @@ an id string that corresponds with the id used to call the module's \code{ui} fu
 \if{html}{\out{<a id="method-FilteredDataset-ui_add"></a>}}
 \if{latex}{\out{\hypertarget{method-FilteredDataset-ui_add}{}}}
 \subsection{Method \code{ui_add()}}{
-\code{ui} module to add filter variable for this dataset.
+UI module to add filter variable for this dataset.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$ui_add(id)}\if{html}{\out{</div>}}
 }
@@ -348,7 +348,7 @@ identifier of the element - preferably containing dataset name}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-function - shiny \code{ui} module
+function - shiny UI module
 }
 }
 \if{html}{\out{<hr>}}
@@ -368,7 +368,8 @@ experiment.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's
+\code{ui_add} function.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/MAEFilteredDataset.Rd
+++ b/man/MAEFilteredDataset.Rd
@@ -145,7 +145,7 @@ specifying \code{FilterState} objects to remove;
 \if{html}{\out{<a id="method-MAEFilteredDataset-ui_add"></a>}}
 \if{latex}{\out{\hypertarget{method-MAEFilteredDataset-ui_add}{}}}
 \subsection{Method \code{ui_add()}}{
-\code{ui} module to add filter variable for this dataset.
+UI module to add filter variable for this dataset.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{MAEFilteredDataset$ui_add(id)}\if{html}{\out{</div>}}
 }
@@ -159,7 +159,7 @@ identifier of the element - preferably containing dataset name}
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-function - shiny \code{ui} module
+function - shiny UI module
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/SEFilterStates.Rd
+++ b/man/SEFilterStates.Rd
@@ -96,7 +96,7 @@ Set filter state.
 \if{html}{\out{<a id="method-SEFilterStates-ui_add"></a>}}
 \if{latex}{\out{\hypertarget{method-SEFilterStates-ui_add}{}}}
 \subsection{Method \code{ui_add()}}{
-Shiny \code{ui} module to add filter variable.
+Shiny UI module to add filter variable.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SEFilterStates$ui_add(id)}\if{html}{\out{</div>}}
 }
@@ -133,7 +133,7 @@ sets of filter variables - one for \code{colData} and another for
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{id}}{(\code{character(1)})
-an id string that corresponds with the id used to call the module's \code{ui} function.}
+an id string that corresponds with the id used to call the module's \code{ui_add} function.}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Changes after feedback on #524 (too big to be merged directly)

- UI was already in `inst/WORDLIST`
- Added `ui_active` in `srv_active` parameter documentation and applied this to other `srv_*` methods.