### PR TITLE
531 warning in example@pre release cleanup@main

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -79,7 +79,7 @@
 #'   teal_slice(dataname = "mae", varname = "gender", selected = "female", keep_na = TRUE),
 #'   teal_slice(
 #'     dataname = "mae", varname = "ARRAY_TYPE",
-#'     selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+#'     selected = "", keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
 #'   )
 #' )
 #' datasets$set_filter_state(state = fs)

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -82,7 +82,7 @@ fs <- teal_slices(
   teal_slice(dataname = "mae", varname = "gender", selected = "female", keep_na = TRUE),
   teal_slice(
     dataname = "mae", varname = "ARRAY_TYPE",
-    selected = "", keep_na = TRUE, datalabel = "RPPAArray", arg = "subset"
+    selected = "", keep_na = TRUE, experiment = "RPPAArray", arg = "subset"
   )
 )
 datasets$set_filter_state(state = fs)


### PR DESCRIPTION
closes #531 
We used to distinguish sub-items of the MAE object by term `datalabel`. We don't do this anymore, this is artifact after the refactor.
