### PR TITLE
Moves `{shiny}` to imports and updates examples/vignettes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,8 +28,7 @@ URL: https://insightsengineering.github.io/teal.slice/,
     https://github.com/insightsengineering/teal.slice/
 BugReports: https://github.com/insightsengineering/teal.slice/issues
 Depends:
-    R (>= 4.0),
-    shiny (>= 1.6.0)
+    R (>= 4.0)
 Imports:
     bslib (>= 0.4.0),
     checkmate (>= 2.1.0),
@@ -42,6 +41,7 @@ Imports:
     methods,
     plotly (>= 4.9.2.2),
     R6 (>= 2.2.0),
+    shiny (>= 1.6.0),
     shinycssloaders (>= 1.0.0),
     shinyjs,
     shinyWidgets (>= 0.6.2),

--- a/R/FilterPanelAPI.R
+++ b/R/FilterPanelAPI.R
@@ -21,7 +21,7 @@
 #' fpa <- FilterPanelAPI$new(fd)
 #'
 #' # get the actual filter state --> empty named list
-#' isolate(fpa$get_filter_state())
+#' shiny::isolate(fpa$get_filter_state())
 #'
 #' # set a filter state
 #' set_filter_state(
@@ -32,13 +32,13 @@
 #' )
 #'
 #' # get the actual filter state --> named list with filters
-#' isolate(fpa$get_filter_state())
+#' shiny::isolate(fpa$get_filter_state())
 #'
 #' # remove all_filter_states
 #' fpa$clear_filter_states()
 #'
 #' # get the actual filter state --> empty named list
-#' isolate(fpa$get_filter_state())
+#' shiny::isolate(fpa$get_filter_state())
 #'
 #' @export
 #'

--- a/R/FilterPanelAPI.R
+++ b/R/FilterPanelAPI.R
@@ -17,11 +17,13 @@
 #' filter panel API.
 #'
 #' @examples
+#' library(shiny)
+#'
 #' fd <- init_filtered_data(list(iris = iris))
 #' fpa <- FilterPanelAPI$new(fd)
 #'
 #' # get the actual filter state --> empty named list
-#' shiny::isolate(fpa$get_filter_state())
+#' isolate(fpa$get_filter_state())
 #'
 #' # set a filter state
 #' set_filter_state(
@@ -32,13 +34,13 @@
 #' )
 #'
 #' # get the actual filter state --> named list with filters
-#' shiny::isolate(fpa$get_filter_state())
+#' isolate(fpa$get_filter_state())
 #'
 #' # remove all_filter_states
 #' fpa$clear_filter_states()
 #'
 #' # get the actual filter state --> empty named list
-#' shiny::isolate(fpa$get_filter_state())
+#' isolate(fpa$get_filter_state())
 #'
 #' @export
 #'

--- a/R/FilterState-utils.R
+++ b/R/FilterState-utils.R
@@ -25,9 +25,11 @@
 #' # use non-exported function from teal.slice
 #' init_filter_state <- getFromNamespace("init_filter_state", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' filter_state <- init_filter_state(
 #'   x = c(1:10, NA, Inf),
-#'   x_reactive = shiny::reactive(c(1:10, NA, Inf)),
+#'   x_reactive = reactive(c(1:10, NA, Inf)),
 #'   slice = teal_slice(
 #'     varname = "varname",
 #'     dataname = "dataname"
@@ -35,25 +37,24 @@
 #'   extract_type = "matrix"
 #' )
 #'
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #'
 #' # working filter in an app
-#' library(shiny)
 #'
 #' ui <- fluidPage(
 #'   filter_state$ui(id = "app"),
-#'   shiny::verbatimTextOutput("call")
+#'   verbatimTextOutput("call")
 #' )
 #' server <- function(input, output, session) {
 #'   filter_state$server("app")
 #'
-#'   output$call <- shiny::renderText(
+#'   output$call <- renderText(
 #'     deparse1(filter_state$get_call(), collapse = "\n")
 #'   )
 #' }
 #'
 #' if (interactive()) {
-#'   shiny::shinyApp(ui, server)
+#'   shinyApp(ui, server)
 #' }
 #'
 #' @return `FilterState` object

--- a/R/FilterState-utils.R
+++ b/R/FilterState-utils.R
@@ -27,7 +27,7 @@
 #'
 #' filter_state <- init_filter_state(
 #'   x = c(1:10, NA, Inf),
-#'   x_reactive = reactive(c(1:10, NA, Inf)),
+#'   x_reactive = shiny::reactive(c(1:10, NA, Inf)),
 #'   slice = teal_slice(
 #'     varname = "varname",
 #'     dataname = "dataname"
@@ -35,22 +35,25 @@
 #'   extract_type = "matrix"
 #' )
 #'
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
+#'
+#' # working filter in an app
+#' library(shiny)
 #'
 #' ui <- fluidPage(
 #'   filter_state$ui(id = "app"),
-#'   verbatimTextOutput("call")
+#'   shiny::verbatimTextOutput("call")
 #' )
 #' server <- function(input, output, session) {
 #'   filter_state$server("app")
 #'
-#'   output$call <- renderText(
+#'   output$call <- shiny::renderText(
 #'     deparse1(filter_state$get_call(), collapse = "\n")
 #'   )
 #' }
 #'
 #' if (interactive()) {
-#'   shinyApp(ui, server)
+#'   shiny::shinyApp(ui, server)
 #' }
 #'
 #' @return `FilterState` object

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -93,7 +93,7 @@ FilterState <- R6::R6Class( # nolint
       private$extract_type <- extract_type
 
       # Set state properties.
-      if (is.null(shiny::isolate(slice$keep_na)) && anyNA(x)) slice$keep_na <- TRUE
+      if (is.null(isolate(slice$keep_na)) && anyNA(x)) slice$keep_na <- TRUE
       private$teal_slice <- slice
       # Obtain variable label.
       varlabel <- attr(x, "label")
@@ -134,7 +134,7 @@ FilterState <- R6::R6Class( # nolint
     #' @param ... additional arguments
     #'
     print = function(...) {
-      cat(shiny::isolate(self$format(...)))
+      cat(isolate(self$format(...)))
     },
 
     #' @description
@@ -152,7 +152,7 @@ FilterState <- R6::R6Class( # nolint
         logger::log_warn("attempt to set state on fixed filter aborted id: { private$get_id() }")
       } else {
         logger::log_trace("{ class(self)[1] }$set_state setting state of filter id: { private$get_id() }")
-        shiny::isolate({
+        isolate({
           if (!is.null(state$selected)) {
             private$set_selected(state$selected)
           }
@@ -429,7 +429,7 @@ FilterState <- R6::R6Class( # nolint
           private$get_id()
         )
       )
-      shiny::isolate({
+      isolate({
         value <- private$cast_and_validate(value)
         value <- private$check_length(value)
         value <- private$remove_out_of_bounds_values(value)
@@ -497,21 +497,21 @@ FilterState <- R6::R6Class( # nolint
     # Returns dataname.
     # @return `character(1)`
     get_dataname = function() {
-      shiny::isolate(private$teal_slice$dataname)
+      isolate(private$teal_slice$dataname)
     },
 
     # @description
     # Get variable name.
     # @return `character(1)`
     get_varname = function() {
-      shiny::isolate(private$teal_slice$varname)
+      isolate(private$teal_slice$varname)
     },
 
     # @description
     # Get id of the teal_slice.
     # @return `character(1)`
     get_id = function() {
-      shiny::isolate(private$teal_slice$id)
+      isolate(private$teal_slice$id)
     },
 
     # @description
@@ -519,7 +519,7 @@ FilterState <- R6::R6Class( # nolint
     # @return
     # Vector describing the available choices. Return type depends on the `FilterState` subclass.
     get_choices = function() {
-      shiny::isolate(private$teal_slice$choices)
+      isolate(private$teal_slice$choices)
     },
 
     # @description
@@ -547,19 +547,19 @@ FilterState <- R6::R6Class( # nolint
     # Check whether this filter is fixed (cannot be changed).
     # @return `logical(1)`
     is_fixed = function() {
-      shiny::isolate(isTRUE(private$teal_slice$fixed))
+      isolate(isTRUE(private$teal_slice$fixed))
     },
 
     # Check whether this filter is anchored (cannot be removed).
     # @return `logical(1)`
     is_anchored = function() {
-      shiny::isolate(isTRUE(private$teal_slice$anchored))
+      isolate(isTRUE(private$teal_slice$anchored))
     },
 
     # Check whether this filter is capable of selecting multiple values.
     # @return `logical(1)`
     is_multiple = function() {
-      shiny::isolate(isTRUE(private$teal_slice$multiple))
+      isolate(isTRUE(private$teal_slice$multiple))
     },
 
     # other ----
@@ -712,7 +712,7 @@ FilterState <- R6::R6Class( # nolint
     keep_na_ui = function(id) {
       ns <- NS(id)
       if (private$na_count > 0) {
-        shiny::isolate({
+        isolate({
           countmax <- private$na_count
           countnow <- private$filtered_na_count()
           ui_input <- checkboxInput(

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -17,7 +17,7 @@
 #'   x = c(LETTERS, NA),
 #'   slice = teal_slice(varname = "var", dataname = "data")
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(
 #'     dataname = "data",
@@ -26,9 +26,10 @@
 #'     keep_na = TRUE
 #'   )
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #'
 #' # working filter in an app
+#' library(shiny)
 #' library(shinyjs)
 #'
 #' data_choices <- c(sample(letters[1:4], 100, replace = TRUE), NA)

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -148,7 +148,7 @@ ChoicesFilterState <- R6::R6Class( # nolint
                           x_reactive = reactive(NULL),
                           slice,
                           extract_type = character(0)) {
-      shiny::isolate({
+      isolate({
         checkmate::assert(
           is.character(x),
           is.factor(x),
@@ -335,7 +335,7 @@ ChoicesFilterState <- R6::R6Class( # nolint
           sprintf("Selection: %s is not a vector of length one. ", toString(values, width = 360)),
           "Maintaining previous selection."
         )
-        values <- shiny::isolate(private$get_selected())
+        values <- isolate(private$get_selected())
       }
       values
     },
@@ -361,7 +361,7 @@ ChoicesFilterState <- R6::R6Class( # nolint
       ns <- NS(id)
 
       # we need to isolate UI to not rettrigger renderUI
-      shiny::isolate({
+      isolate({
         countsmax <- private$choices_counts
         countsnow <- if (!is.null(private$x_reactive())) {
           unname(table(factor(private$x_reactive(), levels = private$get_choices())))
@@ -446,7 +446,7 @@ ChoicesFilterState <- R6::R6Class( # nolint
             }
 
             # update should be based on a change of counts only
-            shiny::isolate({
+            isolate({
               if (private$is_checkboxgroup()) {
                 updateCountBars(
                   inputId = "labels",
@@ -571,10 +571,10 @@ ChoicesFilterState <- R6::R6Class( # nolint
             }
             countsmax <- private$choices_counts
 
-            ind <- private$get_choices() %in% shiny::isolate(private$get_selected())
+            ind <- private$get_choices() %in% isolate(private$get_selected())
             countBars(
               inputId = session$ns("labels"),
-              choices = shiny::isolate(private$get_selected()),
+              choices = isolate(private$get_selected()),
               countsnow = countsnow[ind],
               countsmax = countsmax[ind]
             )

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -13,11 +13,13 @@
 #' include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 #' ChoicesFilterState <- getFromNamespace("ChoicesFilterState", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' filter_state <- ChoicesFilterState$new(
 #'   x = c(LETTERS, NA),
 #'   slice = teal_slice(varname = "var", dataname = "data")
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(
 #'     dataname = "data",
@@ -26,10 +28,9 @@
 #'     keep_na = TRUE
 #'   )
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #'
 #' # working filter in an app
-#' library(shiny)
 #' library(shinyjs)
 #'
 #' data_choices <- c(sample(letters[1:4], 100, replace = TRUE), NA)

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -18,7 +18,7 @@
 #'   slice = teal_slice(varname = "x", dataname = "data"),
 #'   extract_type = character(0)
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(
 #'     dataname = "data",
@@ -27,9 +27,10 @@
 #'     keep_na = TRUE
 #'   )
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #'
 #' # working filter in an app
+#' library(shiny)
 #' library(shinyjs)
 #'
 #' dates <- c(Sys.Date() - 100, Sys.Date())

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -142,7 +142,7 @@ DateFilterState <- R6::R6Class( # nolint
                           x_reactive = reactive(NULL),
                           slice,
                           extract_type = character(0)) {
-      shiny::isolate({
+      isolate({
         checkmate::assert_date(x)
         checkmate::assert_class(x_reactive, "reactive")
 
@@ -277,7 +277,7 @@ DateFilterState <- R6::R6Class( # nolint
     # @param id (`character(1)`) `shiny` module instance id.
     ui_inputs = function(id) {
       ns <- NS(id)
-      shiny::isolate({
+      isolate({
         div(
           div(
             class = "flex",
@@ -425,7 +425,7 @@ DateFilterState <- R6::R6Class( # nolint
       tagList(
         tags$span(
           class = "filter-card-summary-value",
-          shiny::HTML(min, "&ndash;", max)
+          HTML(min, "&ndash;", max)
         ),
         tags$span(
           class = "filter-card-summary-controls",

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -13,12 +13,14 @@
 #' include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 #' DateFilterState <- getFromNamespace("DateFilterState", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' filter_state <- DateFilterState$new(
 #'   x = c(Sys.Date() + seq(1:10), NA),
 #'   slice = teal_slice(varname = "x", dataname = "data"),
 #'   extract_type = character(0)
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(
 #'     dataname = "data",
@@ -27,10 +29,9 @@
 #'     keep_na = TRUE
 #'   )
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #'
 #' # working filter in an app
-#' library(shiny)
 #' library(shinyjs)
 #'
 #' dates <- c(Sys.Date() - 100, Sys.Date())

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -152,7 +152,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
                           x_reactive = reactive(NULL),
                           extract_type = character(0),
                           slice) {
-      shiny::isolate({
+      isolate({
         checkmate::assert_multi_class(x, c("POSIXct", "POSIXlt"))
         checkmate::assert_class(x_reactive, "reactive")
 
@@ -317,7 +317,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
     ui_inputs = function(id) {
       ns <- NS(id)
 
-      shiny::isolate({
+      isolate({
         ui_input_1 <- shinyWidgets::airDatepickerInput(
           inputId = ns("selection_start"),
           value = private$get_selected()[1],
@@ -538,7 +538,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
       tagList(
         tags$span(
           class = "filter-card-summary-value",
-          shiny::HTML(min, "&ndash;", max)
+          HTML(min, "&ndash;", max)
         ),
         tags$span(
           class = "filter-card-summary-controls",

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -13,12 +13,14 @@
 #' include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 #' DatetimeFilterState <- getFromNamespace("DatetimeFilterState", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' filter_state <- DatetimeFilterState$new(
 #'   x = c(Sys.time() + seq(0, by = 3600, length.out = 10), NA),
 #'   slice = teal_slice(varname = "x", dataname = "data"),
 #'   extract_type = character(0)
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(
 #'     dataname = "data",
@@ -27,10 +29,9 @@
 #'     keep_na = TRUE
 #'   )
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #'
 #' # working filter in an app
-#' library(shiny)
 #' library(shinyjs)
 #'
 #' datetimes <- as.POSIXct(c("2012-01-01 12:00:00", "2020-01-01 12:00:00"))

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -18,7 +18,7 @@
 #'   slice = teal_slice(varname = "x", dataname = "data"),
 #'   extract_type = character(0)
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(
 #'     dataname = "data",
@@ -27,9 +27,10 @@
 #'     keep_na = TRUE
 #'   )
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #'
 #' # working filter in an app
+#' library(shiny)
 #' library(shinyjs)
 #'
 #' datetimes <- as.POSIXct(c("2012-01-01 12:00:00", "2020-01-01 12:00:00"))

--- a/R/FilterStateEmpty.R
+++ b/R/FilterStateEmpty.R
@@ -60,7 +60,7 @@ EmptyFilterState <- R6::R6Class( # nolint
                           x_reactive = reactive(NULL),
                           extract_type = character(0),
                           slice) {
-      shiny::isolate({
+      isolate({
         super$initialize(
           x = x,
           x_reactive = x_reactive,
@@ -127,7 +127,7 @@ EmptyFilterState <- R6::R6Class( # nolint
     #
     ui_inputs = function(id) {
       ns <- NS(id)
-      shiny::isolate({
+      isolate({
         div(
           tags$span("Variable contains missing values only"),
           private$keep_na_ui(ns("keep_na"))

--- a/R/FilterStateEmpty.R
+++ b/R/FilterStateEmpty.R
@@ -17,9 +17,9 @@
 #'   slice = teal_slice(varname = "x", dataname = "data"),
 #'   extract_type = character(0)
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #' filter_state$set_state(teal_slice(dataname = "data", varname = "x", keep_na = TRUE))
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #'
 #' @keywords internal
 #'

--- a/R/FilterStateEmpty.R
+++ b/R/FilterStateEmpty.R
@@ -12,14 +12,16 @@
 #' include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 #' EmptyFilterState <- getFromNamespace("EmptyFilterState", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' filter_state <- EmptyFilterState$new(
 #'   x = NA,
 #'   slice = teal_slice(varname = "x", dataname = "data"),
 #'   extract_type = character(0)
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #' filter_state$set_state(teal_slice(dataname = "data", varname = "x", keep_na = TRUE))
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #'
 #' @keywords internal
 #'

--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -29,6 +29,7 @@
 #' filter_state$get_call()
 #'
 #' # working filter in an app
+#' library(shiny)
 #' library(shinyjs)
 #'
 #' ui <- fluidPage(
@@ -175,7 +176,7 @@ FilterStateExpr <- R6::R6Class( # nolint
             lapply(session$ns(names(input)), .subset2(input, "impl")$.values$remove)
           }
 
-          reactive(input$remove) # back to parent to remove self
+          shiny::reactive(input$remove) # back to parent to remove self
         }
       )
     },

--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -100,7 +100,7 @@ FilterStateExpr <- R6::R6Class( # nolint
     #' @return `NULL`, invisibly.
     #'
     print = function(...) {
-      cat(shiny::isolate(self$format(...)))
+      cat(isolate(self$format(...)))
     },
 
     #' @description
@@ -137,7 +137,7 @@ FilterStateExpr <- R6::R6Class( # nolint
     #' @return `call` or `NULL`
     #'
     get_call = function(dataname) {
-      shiny::isolate(str2lang(private$teal_slice$expr))
+      isolate(str2lang(private$teal_slice$expr))
     },
 
     #' @description
@@ -176,7 +176,7 @@ FilterStateExpr <- R6::R6Class( # nolint
             lapply(session$ns(names(input)), .subset2(input, "impl")$.values$remove)
           }
 
-          shiny::reactive(input$remove) # back to parent to remove self
+          reactive(input$remove) # back to parent to remove self
         }
       )
     },
@@ -190,7 +190,7 @@ FilterStateExpr <- R6::R6Class( # nolint
     #'   id of the `FilterStates` card container.
     ui = function(id, parent_id = "cards") {
       ns <- NS(id)
-      shiny::isolate({
+      isolate({
         tags$div(
           id = id,
           class = "panel filter-card",
@@ -239,13 +239,13 @@ FilterStateExpr <- R6::R6Class( # nolint
     # Get id of the teal_slice.
     # @return `character(1)`
     get_id = function() {
-      shiny::isolate(private$teal_slice$id)
+      isolate(private$teal_slice$id)
     },
 
     # Check whether this filter is anchored (cannot be removed).
     # @return `logical(1)`
     is_anchored = function() {
-      shiny::isolate(isTRUE(private$teal_slice$anchored))
+      isolate(isTRUE(private$teal_slice$anchored))
     },
 
     # @description
@@ -269,7 +269,7 @@ FilterStateExpr <- R6::R6Class( # nolint
       )
     },
     content_summary = function() {
-      shiny::isolate(private$teal_slice$expr)
+      isolate(private$teal_slice$expr)
     }
   )
 )

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -127,7 +127,7 @@ LogicalFilterState <- R6::R6Class( # nolint
                           x_reactive = reactive(NULL),
                           extract_type = character(0),
                           slice) {
-      shiny::isolate({
+      isolate({
         checkmate::assert_logical(x)
         checkmate::assert_logical(slice$selected, null.ok = TRUE)
         super$initialize(x = x, x_reactive = x_reactive, slice = slice, extract_type = extract_type)
@@ -206,7 +206,7 @@ LogicalFilterState <- R6::R6Class( # nolint
           sprintf("Selection: %s is not a vector of length one. ", toString(values, width = 360)),
           "Maintaining previous selection."
         )
-        values <- shiny::isolate(private$get_selected())
+        values <- isolate(private$get_selected())
       }
       values
     },
@@ -239,7 +239,7 @@ LogicalFilterState <- R6::R6Class( # nolint
     # @param id (`character(1)`) `shiny` module instance id.
     ui_inputs = function(id) {
       ns <- NS(id)
-      shiny::isolate({
+      isolate({
         countsmax <- private$choices_counts
         countsnow <- if (!is.null(private$x_reactive())) {
           unname(table(factor(private$x_reactive(), levels = private$get_choices())))
@@ -257,7 +257,7 @@ LogicalFilterState <- R6::R6Class( # nolint
           checkboxGroupInput(
             inputId = ns("selection"),
             label = NULL,
-            selected = shiny::isolate(as.character(private$get_selected())),
+            selected = isolate(as.character(private$get_selected())),
             choiceNames = labels,
             choiceValues = factor(as.character(private$get_choices()), levels = c("TRUE", "FALSE")),
             width = "100%"
@@ -266,7 +266,7 @@ LogicalFilterState <- R6::R6Class( # nolint
           radioButtons(
             inputId = ns("selection"),
             label = NULL,
-            selected = shiny::isolate(as.character(private$get_selected())),
+            selected = isolate(as.character(private$get_selected())),
             choiceNames = labels,
             choiceValues = factor(as.character(private$get_choices()), levels = c("TRUE", "FALSE")),
             width = "100%"

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -13,18 +13,18 @@
 #' include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 #' LogicalFilterState <- getFromNamespace("LogicalFilterState", "teal.slice")
 #'
-#'
 #' filter_state <- LogicalFilterState$new(
 #'   x = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
 #'   slice = teal_slice(varname = "x", dataname = "data")
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(dataname = "data", varname = "x", selected = TRUE, keep_na = TRUE)
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #'
 #' # working filter in an app
+#' library(shiny)
 #' library(shinyjs)
 #'
 #' data_logical <- c(sample(c(TRUE, FALSE), 10, replace = TRUE), NA)

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -13,18 +13,19 @@
 #' include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 #' LogicalFilterState <- getFromNamespace("LogicalFilterState", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' filter_state <- LogicalFilterState$new(
 #'   x = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
 #'   slice = teal_slice(varname = "x", dataname = "data")
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(dataname = "data", varname = "x", selected = TRUE, keep_na = TRUE)
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #'
 #' # working filter in an app
-#' library(shiny)
 #' library(shinyjs)
 #'
 #' data_logical <- c(sample(c(TRUE, FALSE), 10, replace = TRUE), NA)

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -17,7 +17,7 @@
 #'   x = c(NA, Inf, seq(1:10)),
 #'   slice = teal_slice(varname = "x", dataname = "data")
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(
 #'     dataname = "data",
@@ -27,9 +27,10 @@
 #'     keep_inf = TRUE
 #'   )
 #' )
-#' isolate(filter_state$get_call())
+#' shiny::isolate(filter_state$get_call())
 #'
 #' # working filter in an app
+#' library(shiny)
 #' library(shinyjs)
 #'
 #' data_range <- c(runif(100, 0, 1), NA, Inf)

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -154,7 +154,7 @@ RangeFilterState <- R6::R6Class( # nolint
                           x_reactive = reactive(NULL),
                           extract_type = character(0),
                           slice) {
-      shiny::isolate({
+      isolate({
         checkmate::assert_numeric(x, all.missing = FALSE)
         if (!any(is.finite(x))) stop("\"x\" contains no finite values")
         super$initialize(x = x, x_reactive = x_reactive, slice = slice, extract_type = extract_type)
@@ -408,7 +408,7 @@ RangeFilterState <- R6::R6Class( # nolint
     # @param id (`character(1)`) `shiny` module instance id.
     ui_inputs = function(id) {
       ns <- NS(id)
-      shiny::isolate({
+      isolate({
         ui_input <- shinyWidgets::numericRangeInput(
           inputId = ns("selection_manual"),
           label = NULL,
@@ -642,7 +642,7 @@ RangeFilterState <- R6::R6Class( # nolint
     content_summary = function() {
       selection <- private$get_selected()
       tagList(
-        tags$span(shiny::HTML(selection[1], "&ndash;", selection[2]), class = "filter-card-summary-value"),
+        tags$span(HTML(selection[1], "&ndash;", selection[2]), class = "filter-card-summary-value"),
         tags$span(
           class = "filter-card-summary-controls",
           if (private$na_count > 0) {

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -13,11 +13,13 @@
 #' include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 #' RangeFilterState <- getFromNamespace("RangeFilterState", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' filter_state <- RangeFilterState$new(
 #'   x = c(NA, Inf, seq(1:10)),
 #'   slice = teal_slice(varname = "x", dataname = "data")
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #' filter_state$set_state(
 #'   teal_slice(
 #'     dataname = "data",
@@ -27,10 +29,9 @@
 #'     keep_inf = TRUE
 #'   )
 #' )
-#' shiny::isolate(filter_state$get_call())
+#' isolate(filter_state$get_call())
 #'
 #' # working filter in an app
-#' library(shiny)
 #' library(shinyjs)
 #'
 #' data_range <- c(runif(100, 0, 1), NA, Inf)

--- a/R/FilterStates-utils.R
+++ b/R/FilterStates-utils.R
@@ -33,6 +33,7 @@
 #'   dataname = "DF"
 #' )
 #'
+#' library(shiny)
 #' ui <- fluidPage(
 #'   actionButton("clear", span(icon("xmark"), "Remove all filters")),
 #'   rf$ui_add(id = "add"),

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -188,7 +188,7 @@ FilterStates <- R6::R6Class( # nolint
     #'
     #' @param ... additional arguments passed to `format`.
     print = function(...) {
-      cat(shiny::isolate(self$format(...)), "\n")
+      cat(isolate(self$format(...)), "\n")
     },
 
     #' @description
@@ -202,7 +202,7 @@ FilterStates <- R6::R6Class( # nolint
     #'
     remove_filter_state = function(state) {
       checkmate::assert_class(state, "teal_slices")
-      shiny::isolate({
+      isolate({
         state_ids <- vapply(state, `[[`, character(1), "id")
         logger::log_trace("{ class(self)[1] }$remove_filter_state removing filters, state_id: { toString(state_ids) }")
         private$state_list_remove(state_ids)
@@ -246,7 +246,7 @@ FilterStates <- R6::R6Class( # nolint
     #' @param state (`teal_slices`)
     #' @return Function that raises an error.
     set_filter_state = function(state) {
-      shiny::isolate({
+      isolate({
         logger::log_trace("{ class(self)[1] }$set_filter_state initializing, dataname: { private$dataname }")
         checkmate::assert_class(state, "teal_slices")
         lapply(state, function(x) {
@@ -357,11 +357,11 @@ FilterStates <- R6::R6Class( # nolint
             })
           })
 
-          output[["cards"]] <- shiny::renderUI({
+          output[["cards"]] <- renderUI({
             lapply(
               current_state(), # observes only if added/removed
               function(state) {
-                shiny::isolate( # isolates when existing state changes
+                isolate( # isolates when existing state changes
                   state$ui(id = session$ns(fs_to_shiny_ns(state)), parent_id = session$ns("cards"))
                 )
               }
@@ -609,10 +609,10 @@ FilterStates <- R6::R6Class( # nolint
       checkmate::assert_multi_class(x, c("FilterState", "FilterStateExpr"))
       state <- stats::setNames(list(x), state_id)
       new_state_list <- c(
-        shiny::isolate(private$state_list()),
+        isolate(private$state_list()),
         state
       )
-      shiny::isolate(private$state_list(new_state_list))
+      isolate(private$state_list(new_state_list))
 
       logger::log_trace("{ class(self)[1] } pushed into queue, dataname: { private$dataname }")
       invisible(NULL)
@@ -635,7 +635,7 @@ FilterStates <- R6::R6Class( # nolint
       checkmate::assert_character(state_id)
       logger::log_trace("{ class(self)[1] } removing a filter, state_id: { toString(state_id) }")
 
-      shiny::isolate({
+      isolate({
         current_state_ids <- vapply(private$state_list(), function(x) x$get_state()$id, character(1))
         to_remove <- state_id %in% current_state_ids
         if (any(to_remove)) {
@@ -670,7 +670,7 @@ FilterStates <- R6::R6Class( # nolint
     # @return `NULL`, invisibly.
     #
     state_list_empty = function(force = FALSE) {
-      shiny::isolate({
+      isolate({
         logger::log_trace(
           "{ class(self)[1] }$state_list_empty removing all non-anchored filters for dataname: { private$dataname }"
         )
@@ -715,7 +715,7 @@ FilterStates <- R6::R6Class( # nolint
         )
       }
 
-      state_list <- shiny::isolate(private$state_list_get())
+      state_list <- isolate(private$state_list_get())
       lapply(state, function(slice) {
         state_id <- slice$id
         if (state_id %in% names(state_list)) {

--- a/R/FilterStatesDF.R
+++ b/R/FilterStatesDF.R
@@ -13,6 +13,7 @@
 #' include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 #' init_filter_states <- getFromNamespace("init_filter_states", "teal.slice")
 #'
+#' library(shiny)
 #' library(shinyjs)
 #'
 #' # create data frame to filter

--- a/R/FilterStatesSE.R
+++ b/R/FilterStatesSE.R
@@ -52,7 +52,7 @@ SEFilterStates <- R6::R6Class( # nolint
     #' @return `NULL`, invisibly.
     #'
     set_filter_state = function(state) {
-      shiny::isolate({
+      isolate({
         logger::log_trace("{ class(self)[1] }$set_filter_state initializing, dataname: { private$dataname }")
         checkmate::assert_class(state, "teal_slices")
         lapply(state, function(x) {

--- a/R/FilteredData-utils.R
+++ b/R/FilteredData-utils.R
@@ -87,6 +87,7 @@ eval_expr_with_msg <- function(expr, env) {
 #' # use non-exported function from teal.slice
 #' toggle_icon <- getFromNamespace("toggle_icon", "teal.slice")
 #'
+#' library(shiny)
 #' library(shinyjs)
 #'
 #' ui <- fluidPage(

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -64,7 +64,7 @@
 #' ### set_filter_state
 #' library(shiny)
 #'
-#' utils::data(miniACC, package = "MultiAssayExperiment")
+#' data(miniACC, package = "MultiAssayExperiment")
 #' datasets <- FilteredData$new(list(iris = iris, mae = miniACC))
 #' fs <- teal_slices(
 #'   teal_slice(

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -40,6 +40,8 @@
 #' # use non-exported function from teal.slice
 #' FilteredData <- getFromNamespace("FilteredData", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' datasets <- FilteredData$new(list(iris = iris, mtcars = mtcars))
 #'
 #' # get datanames
@@ -48,18 +50,19 @@
 #' datasets$set_filter_state(
 #'   teal_slices(teal_slice(dataname = "iris", varname = "Species", selected = "virginica"))
 #' )
-#' shiny::isolate(datasets$get_call("iris"))
+#' isolate(datasets$get_call("iris"))
 #'
 #' datasets$set_filter_state(
 #'   teal_slices(teal_slice(dataname = "mtcars", varname = "mpg", selected = c(15, 20)))
 #' )
 #'
-#' shiny::isolate(datasets$get_filter_state())
-#' shiny::isolate(datasets$get_call("iris"))
-#' shiny::isolate(datasets$get_call("mtcars"))
+#' isolate(datasets$get_filter_state())
+#' isolate(datasets$get_call("iris"))
+#' isolate(datasets$get_call("mtcars"))
 #'
 #' @examplesIf requireNamespace("MultiAssayExperiment")
 #' ### set_filter_state
+#' library(shiny)
 #'
 #' utils::data(miniACC, package = "MultiAssayExperiment")
 #' datasets <- FilteredData$new(list(iris = iris, mae = miniACC))
@@ -84,7 +87,7 @@
 #'   )
 #' )
 #' datasets$set_filter_state(state = fs)
-#' shiny::isolate(datasets$get_filter_state())
+#' isolate(datasets$get_filter_state())
 #'
 #' @keywords internal
 #'

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -48,15 +48,15 @@
 #' datasets$set_filter_state(
 #'   teal_slices(teal_slice(dataname = "iris", varname = "Species", selected = "virginica"))
 #' )
-#' isolate(datasets$get_call("iris"))
+#' shiny::isolate(datasets$get_call("iris"))
 #'
 #' datasets$set_filter_state(
 #'   teal_slices(teal_slice(dataname = "mtcars", varname = "mpg", selected = c(15, 20)))
 #' )
 #'
-#' isolate(datasets$get_filter_state())
-#' isolate(datasets$get_call("iris"))
-#' isolate(datasets$get_call("mtcars"))
+#' shiny::isolate(datasets$get_filter_state())
+#' shiny::isolate(datasets$get_call("iris"))
+#' shiny::isolate(datasets$get_call("mtcars"))
 #'
 #' @examplesIf requireNamespace("MultiAssayExperiment")
 #' ### set_filter_state
@@ -84,7 +84,7 @@
 #'   )
 #' )
 #' datasets$set_filter_state(state = fs)
-#' isolate(datasets$get_filter_state())
+#' shiny::isolate(datasets$get_filter_state())
 #'
 #' @keywords internal
 #'

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -395,7 +395,7 @@ FilteredData <- R6::R6Class( # nolint
     #' @param ... additional arguments passed to `format`.
     #'
     print = function(...) {
-      cat(shiny::isolate(self$format(...)), "\n")
+      cat(isolate(self$format(...)), "\n")
     },
 
     #' @description
@@ -405,7 +405,7 @@ FilteredData <- R6::R6Class( # nolint
     #'
     #' @return `NULL`, invisibly.
     set_filter_state = function(state) {
-      shiny::isolate({
+      isolate({
         logger::log_trace("{ class(self)[1] }$set_filter_state initializing")
         checkmate::assert_class(state, "teal_slices")
         allow_add <- attr(state, "allow_add")
@@ -434,7 +434,7 @@ FilteredData <- R6::R6Class( # nolint
     #' @return `NULL`, invisibly.
     #'
     remove_filter_state = function(state) {
-      shiny::isolate({
+      isolate({
         checkmate::assert_class(state, "teal_slices")
         datanames <- unique(vapply(state, "[[", character(1L), "dataname"))
         checkmate::assert_subset(datanames, self$datanames())
@@ -604,7 +604,7 @@ FilteredData <- R6::R6Class( # nolint
     #' @return `NULL`.
     srv_active = function(id, active_datanames = self$datanames) {
       checkmate::assert_function(active_datanames)
-      shiny::moduleServer(id, function(input, output, session) {
+      moduleServer(id, function(input, output, session) {
         logger::log_trace("FilteredData$srv_active initializing")
 
         private$srv_available_filters("available_filters")
@@ -644,9 +644,9 @@ FilteredData <- R6::R6Class( # nolint
           }
         )
 
-        output$teal_filters_count <- shiny::renderText({
+        output$teal_filters_count <- renderText({
           n_filters_active <- private$get_filter_count()
-          shiny::req(n_filters_active > 0L)
+          req(n_filters_active > 0L)
           sprintf(
             "%s filter%s applied across datasets",
             n_filters_active,
@@ -717,7 +717,7 @@ FilteredData <- R6::R6Class( # nolint
       checkmate::assert_class(active_datanames, "reactive")
       moduleServer(id, function(input, output, session) {
         logger::log_trace("FilteredData$srv_add initializing")
-        shiny::observeEvent(input$minimise_filter_add_vars, {
+        observeEvent(input$minimise_filter_add_vars, {
           shinyjs::toggle("filter_add_vars_contents")
           toggle_icon(session$ns("minimise_filter_add_vars"), c("fa-angle-right", "fa-angle-down"))
           toggle_title(session$ns("minimise_filter_add_vars"), c("Restore panel", "Minimise Panel"))
@@ -809,7 +809,7 @@ FilteredData <- R6::R6Class( # nolint
         function(input, output, session) {
           logger::log_trace("FilteredData$srv_filter_overview initializing")
 
-          shiny::observeEvent(input$minimise_filter_overview, {
+          observeEvent(input$minimise_filter_overview, {
             shinyjs::toggle("filters_overview_contents")
             toggle_icon(session$ns("minimise_filter_overview"), c("fa-angle-right", "fa-angle-down"))
             toggle_title(session$ns("minimise_filter_overview"), c("Restore panel", "Minimise Panel"))
@@ -951,7 +951,7 @@ FilteredData <- R6::R6Class( # nolint
     ui_available_filters = function(id) {
       ns <- NS(id)
 
-      active_slices_id <- shiny::isolate(vapply(self$get_filter_state(), `[[`, character(1), "id"))
+      active_slices_id <- isolate(vapply(self$get_filter_state(), `[[`, character(1), "id"))
       div(
         id = ns("available_menu"),
         shinyWidgets::dropMenu(
@@ -1025,7 +1025,7 @@ FilteredData <- R6::R6Class( # nolint
 
           checkbox_group_slice <- function(slice) {
             # we need to isolate changes in the fields of the slice (teal_slice)
-            shiny::isolate({
+            isolate({
               checkbox_group_element(
                 name = session$ns("available_slices_id"),
                 value = slice$id,

--- a/R/FilteredDataset-utils.R
+++ b/R/FilteredDataset-utils.R
@@ -53,7 +53,6 @@
 #'
 #' @examplesIf requireNamespace("MultiAssayExperiment")
 #' # MAEFilteredDataset example
-#' library(MultiAssayExperiment)
 #' library(shiny)
 #'
 #' data(miniACC, package = "MultiAssayExperiment")

--- a/R/FilteredDataset-utils.R
+++ b/R/FilteredDataset-utils.R
@@ -28,6 +28,8 @@
 #'
 #' @examples
 #' # DataframeFilteredDataset example
+#' library(shiny)
+#'
 #' iris_fd <- init_filtered_dataset(iris, dataname = "iris")
 #' ui <- fluidPage(
 #'   iris_fd$ui_add(id = "add"),
@@ -52,6 +54,8 @@
 #' @examplesIf requireNamespace("MultiAssayExperiment")
 #' # MAEFilteredDataset example
 #' library(MultiAssayExperiment)
+#' library(shiny)
+#'
 #' data(miniACC, package = "MultiAssayExperiment")
 #'
 #' MAE_fd <- init_filtered_dataset(miniACC, "MAE")

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -85,7 +85,7 @@ FilteredDataset <- R6::R6Class( # nolint
     #' @param ... additional arguments passed to `format`.
     #'
     print = function(...) {
-      cat(shiny::isolate(self$format(...)), "\n")
+      cat(isolate(self$format(...)), "\n")
     },
 
     #' @description
@@ -301,14 +301,14 @@ FilteredDataset <- R6::R6Class( # nolint
             }
           )
 
-          shiny::observeEvent(self$get_filter_state(), {
+          observeEvent(self$get_filter_state(), {
             shinyjs::hide("filter_count_ui")
             shinyjs::show("filters")
             shinyjs::toggle("remove_filters", condition = length(self$get_filter_state()) != 0)
             shinyjs::toggle("collapse", condition = length(self$get_filter_state()) != 0)
           })
 
-          shiny::observeEvent(input$collapse, {
+          observeEvent(input$collapse, {
             shinyjs::toggle("filter_count_ui")
             shinyjs::toggle("filters")
             toggle_icon(session$ns("collapse"), c("fa-angle-right", "fa-angle-down"))

--- a/R/FilteredDatasetDataframe.R
+++ b/R/FilteredDatasetDataframe.R
@@ -15,8 +15,8 @@
 #'     teal_slice(dataname = "iris", varname = "Petal.Length", selected = c(2.0, 5))
 #'   )
 #' )
-#' isolate(ds$get_filter_state())
-#' isolate(ds$get_call())
+#' shiny::isolate(ds$get_filter_state())
+#' shiny::isolate(ds$get_call())
 #'
 #' ## set_filter_state
 #' dataset <- DataframeFilteredDataset$new(iris, "iris")
@@ -25,7 +25,7 @@
 #'   teal_slice(dataname = "iris", varname = "Petal.Length", selected = c(2.0, 5))
 #' )
 #' dataset$set_filter_state(state = fs)
-#' isolate(dataset$get_filter_state())
+#' shiny::isolate(dataset$get_filter_state())
 #'
 #' @keywords internal
 #'

--- a/R/FilteredDatasetDataframe.R
+++ b/R/FilteredDatasetDataframe.R
@@ -188,7 +188,7 @@ DataframeFilteredDataset <- R6::R6Class( # nolint
     #' @return `NULL`, invisibly.
     #'
     set_filter_state = function(state) {
-      shiny::isolate({
+      isolate({
         logger::log_trace("{ class(self)[1] }$set_filter_state initializing, dataname: { private$dataname }")
         checkmate::assert_class(state, "teal_slices")
         lapply(state, function(slice) {
@@ -211,7 +211,7 @@ DataframeFilteredDataset <- R6::R6Class( # nolint
     remove_filter_state = function(state) {
       checkmate::assert_class(state, "teal_slices")
 
-      shiny::isolate({
+      isolate({
         logger::log_trace("{ class(self)[1] }$remove_filter_state removing filter(s), dataname: { private$dataname }")
 
         varnames <- unique(unlist(lapply(state, "[[", "varname")))

--- a/R/FilteredDatasetDataframe.R
+++ b/R/FilteredDatasetDataframe.R
@@ -8,6 +8,8 @@
 #' # use non-exported function from teal.slice
 #' DataframeFilteredDataset <- getFromNamespace("DataframeFilteredDataset", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' ds <- DataframeFilteredDataset$new(iris, "iris")
 #' ds$set_filter_state(
 #'   teal_slices(
@@ -15,8 +17,8 @@
 #'     teal_slice(dataname = "iris", varname = "Petal.Length", selected = c(2.0, 5))
 #'   )
 #' )
-#' shiny::isolate(ds$get_filter_state())
-#' shiny::isolate(ds$get_call())
+#' isolate(ds$get_filter_state())
+#' isolate(ds$get_call())
 #'
 #' ## set_filter_state
 #' dataset <- DataframeFilteredDataset$new(iris, "iris")
@@ -25,7 +27,7 @@
 #'   teal_slice(dataname = "iris", varname = "Petal.Length", selected = c(2.0, 5))
 #' )
 #' dataset$set_filter_state(state = fs)
-#' shiny::isolate(dataset$get_filter_state())
+#' isolate(dataset$get_filter_state())
 #'
 #' @keywords internal
 #'

--- a/R/FilteredDatasetDefault.R
+++ b/R/FilteredDatasetDefault.R
@@ -10,9 +10,11 @@
 #' # use non-exported function from teal.slice
 #' DefaultFilteredDataset <- getFromNamespace("DefaultFilteredDataset", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' ds <- DefaultFilteredDataset$new(letters, "letters")
-#' shiny::isolate(ds$get_filter_state())
-#' shiny::isolate(ds$get_call())
+#' isolate(ds$get_filter_state())
+#' isolate(ds$get_call())
 #'
 #' @keywords internal
 #'

--- a/R/FilteredDatasetDefault.R
+++ b/R/FilteredDatasetDefault.R
@@ -11,8 +11,8 @@
 #' DefaultFilteredDataset <- getFromNamespace("DefaultFilteredDataset", "teal.slice")
 #'
 #' ds <- DefaultFilteredDataset$new(letters, "letters")
-#' isolate(ds$get_filter_state())
-#' isolate(ds$get_call())
+#' shiny::isolate(ds$get_filter_state())
+#' shiny::isolate(ds$get_call())
 #'
 #' @keywords internal
 #'

--- a/R/FilteredDatasetMAE.R
+++ b/R/FilteredDatasetMAE.R
@@ -25,7 +25,7 @@
 #'   )
 #' )
 #' dataset$set_filter_state(state = fs)
-#' isolate(dataset$get_filter_state())
+#' shiny::isolate(dataset$get_filter_state())
 #'
 #' @keywords internal
 #'

--- a/R/FilteredDatasetMAE.R
+++ b/R/FilteredDatasetMAE.R
@@ -8,7 +8,7 @@
 #' # use non-exported function from teal.slice
 #' MAEFilteredDataset <- getFromNamespace("MAEFilteredDataset", "teal.slice")
 #'
-#' utils::data(miniACC, package = "MultiAssayExperiment")
+#' data(miniACC, package = "MultiAssayExperiment")
 #' dataset <- MAEFilteredDataset$new(miniACC, "MAE")
 #' fs <- teal_slices(
 #'   teal_slice(
@@ -25,7 +25,9 @@
 #'   )
 #' )
 #' dataset$set_filter_state(state = fs)
-#' shiny::isolate(dataset$get_filter_state())
+#'
+#' library(shiny)
+#' isolate(dataset$get_filter_state())
 #'
 #' @keywords internal
 #'

--- a/R/FilteredDatasetMAE.R
+++ b/R/FilteredDatasetMAE.R
@@ -97,7 +97,7 @@ MAEFilteredDataset <- R6::R6Class( # nolint
     #' @return `NULL`, invisibly.
     #'
     set_filter_state = function(state) {
-      shiny::isolate({
+      isolate({
         logger::log_trace("{ class(self)[1] }$set_filter_state initializing, dataname: { private$dataname }")
         checkmate::assert_class(state, "teal_slices")
         lapply(state, function(x) {
@@ -146,7 +146,7 @@ MAEFilteredDataset <- R6::R6Class( # nolint
     remove_filter_state = function(state) {
       checkmate::assert_class(state, "teal_slices")
 
-      shiny::isolate({
+      isolate({
         logger::log_trace("{ class(self)[1] }$remove_filter_state removing filter(s), dataname: { private$dataname }")
         # remove state on subjects
         subject_state <- Filter(function(x) is.null(x$experiment), state)

--- a/R/count_labels.R
+++ b/R/count_labels.R
@@ -27,6 +27,8 @@
 #' countBars <- getFromNamespace("countBars", "teal.slice")
 #' updateCountBars <- getFromNamespace("updateCountBars", "teal.slice")
 #'
+#' library(shiny)
+#'
 #' choices <- sample(as.factor(c("a", "b", "c")), size = 20, replace = TRUE)
 #' counts <- table(choices)
 #' labels <- countBars(
@@ -35,8 +37,6 @@
 #'   countsmax = counts,
 #'   countsnow = unname(counts)
 #' )
-#'
-#' library(shiny)
 #'
 #' ui <- fluidPage(
 #'   div(

--- a/R/count_labels.R
+++ b/R/count_labels.R
@@ -36,6 +36,7 @@
 #'   countsnow = unname(counts)
 #' )
 #'
+#' library(shiny)
 #'
 #' ui <- fluidPage(
 #'   div(

--- a/R/filter_panel_api.R
+++ b/R/filter_panel_api.R
@@ -125,10 +125,10 @@ set_filter_state <- function(datasets, filter) {
 #' @export
 get_filter_state <- function(datasets) {
   checkmate::assert_multi_class(datasets, c("FilteredData", "FilterPanelAPI"))
-  if (shiny::isRunning()) {
+  if (isRunning()) {
     datasets$get_filter_state()
   } else {
-    shiny::isolate(datasets$get_filter_state())
+    isolate(datasets$get_filter_state())
   }
 }
 

--- a/R/filter_panel_api.R
+++ b/R/filter_panel_api.R
@@ -63,8 +63,7 @@
 #' @examplesIf requireNamespace("MultiAssayExperiment")
 #'
 #' # Requires MultiAssayExperiment from Bioconductor
-#' library(MultiAssayExperiment)
-#' data(miniACC)
+#' data(miniACC, package = "MultiAssayExperiment")
 #'
 #' datasets <- init_filtered_data(list(mae = miniACC))
 #' fs <- teal_slices(

--- a/R/include_css_js.R
+++ b/R/include_css_js.R
@@ -13,5 +13,5 @@ include_css_files <- function(pattern = "*") {
     system.file("css", package = "teal.slice", mustWork = TRUE),
     pattern = pattern, full.names = TRUE
   )
-  return(shiny::singleton(shiny::tags$head(lapply(css_files, shiny::includeCSS))))
+  return(singleton(tags$head(lapply(css_files, includeCSS))))
 }

--- a/R/include_css_js.R
+++ b/R/include_css_js.R
@@ -13,5 +13,5 @@ include_css_files <- function(pattern = "*") {
     system.file("css", package = "teal.slice", mustWork = TRUE),
     pattern = pattern, full.names = TRUE
   )
-  return(singleton(tags$head(lapply(css_files, includeCSS))))
+  singleton(tags$head(lapply(css_files, includeCSS)))
 }

--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -140,7 +140,7 @@ teal_slice <- function(dataname,
     formal_args$fixed <- TRUE
     ts_expr_args <- c("dataname", "id", "expr", "fixed", "anchored", "title")
     formal_args <- formal_args[ts_expr_args]
-    ans <- do.call(shiny::reactiveValues, c(formal_args, list(...)))
+    ans <- do.call(reactiveValues, c(formal_args, list(...)))
     class(ans) <- c("teal_slice_expr", "teal_slice", class(ans))
   } else if (!missing(varname)) {
     checkmate::assert_string(varname)
@@ -163,7 +163,7 @@ teal_slice <- function(dataname,
     } else {
       checkmate::assert_string(id)
     }
-    ans <- do.call(shiny::reactiveValues, args)
+    ans <- do.call(reactiveValues, args)
     class(ans) <- c("teal_slice_var", "teal_slice", class(ans))
   } else {
     stop("Must provide either `expr` or `varname`.")
@@ -196,10 +196,10 @@ as.teal_slice <- function(x) { # nolint
 as.list.teal_slice <- function(x, ...) {
   formal_args <- setdiff(names(formals(teal_slice)), "...")
 
-  x <- if (shiny::isRunning()) {
-    shiny::reactiveValuesToList(x)
+  x <- if (isRunning()) {
+    reactiveValuesToList(x)
   } else {
-    shiny::isolate(shiny::reactiveValuesToList(x))
+    isolate(reactiveValuesToList(x))
   }
 
   formal_args <- intersect(formal_args, names(x))
@@ -368,7 +368,7 @@ trim_lines_json <- function(x) {
 #' @keywords internal
 get_default_slice_id <- function(x) {
   checkmate::assert_multi_class(x, c("teal_slice", "list"))
-  shiny::isolate({
+  isolate({
     if (inherits(x, "teal_slice_expr") || is.null(x$varname)) {
       x$id
     } else {

--- a/R/teal_slices.R
+++ b/R/teal_slices.R
@@ -97,7 +97,7 @@ teal_slices <- function(...,
                         allow_add = TRUE) {
   slices <- list(...)
   checkmate::assert_list(slices, types = "teal_slice", any.missing = FALSE)
-  slices_id <- shiny::isolate(vapply(slices, `[[`, character(1L), "id"))
+  slices_id <- isolate(vapply(slices, `[[`, character(1L), "id"))
   if (any(duplicated(slices_id))) {
     stop(
       "Some teal_slice objects have the same id:\n",

--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -4,7 +4,7 @@
 #' @noRd
 #' @keywords internal
 compare_slices <- function(ts1, ts2, fields) {
-  shiny::isolate(
+  isolate(
     all(vapply(fields, function(x) identical(ts1[[x]], ts2[[x]]), logical(1L)))
   )
 }
@@ -14,7 +14,7 @@ compare_slices <- function(ts1, ts2, fields) {
 #' @noRd
 #' @keywords internal
 expect_identical_slice <- function(x, y) {
-  shiny::isolate({
+  isolate({
     testthat::expect_true(
       setequal(
         reactiveValuesToList(x),
@@ -28,7 +28,7 @@ expect_identical_slice <- function(x, y) {
 #' @noRd
 #' @keywords internal
 expect_identical_slices <- function(x, y) {
-  shiny::isolate({
+  isolate({
     mapply(
       function(x, y) {
         expect_identical_slice(x, y)

--- a/man/ChoicesFilterState.Rd
+++ b/man/ChoicesFilterState.Rd
@@ -17,7 +17,7 @@ filter_state <- ChoicesFilterState$new(
   x = c(LETTERS, NA),
   slice = teal_slice(varname = "var", dataname = "data")
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(
     dataname = "data",
@@ -26,9 +26,10 @@ filter_state$set_state(
     keep_na = TRUE
   )
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 
 # working filter in an app
+library(shiny)
 library(shinyjs)
 
 data_choices <- c(sample(letters[1:4], 100, replace = TRUE), NA)

--- a/man/ChoicesFilterState.Rd
+++ b/man/ChoicesFilterState.Rd
@@ -13,11 +13,13 @@ include_css_files <- getFromNamespace("include_css_files", "teal.slice")
 include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 ChoicesFilterState <- getFromNamespace("ChoicesFilterState", "teal.slice")
 
+library(shiny)
+
 filter_state <- ChoicesFilterState$new(
   x = c(LETTERS, NA),
   slice = teal_slice(varname = "var", dataname = "data")
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(
     dataname = "data",
@@ -26,10 +28,9 @@ filter_state$set_state(
     keep_na = TRUE
   )
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 
 # working filter in an app
-library(shiny)
 library(shinyjs)
 
 data_choices <- c(sample(letters[1:4], 100, replace = TRUE), NA)

--- a/man/DFFilterStates.Rd
+++ b/man/DFFilterStates.Rd
@@ -13,6 +13,7 @@ include_css_files <- getFromNamespace("include_css_files", "teal.slice")
 include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 init_filter_states <- getFromNamespace("init_filter_states", "teal.slice")
 
+library(shiny)
 library(shinyjs)
 
 # create data frame to filter

--- a/man/DataframeFilteredDataset.Rd
+++ b/man/DataframeFilteredDataset.Rd
@@ -13,6 +13,8 @@ The \code{DataframeFilteredDataset} \code{R6} class
 # use non-exported function from teal.slice
 DataframeFilteredDataset <- getFromNamespace("DataframeFilteredDataset", "teal.slice")
 
+library(shiny)
+
 ds <- DataframeFilteredDataset$new(iris, "iris")
 ds$set_filter_state(
   teal_slices(
@@ -20,8 +22,8 @@ ds$set_filter_state(
     teal_slice(dataname = "iris", varname = "Petal.Length", selected = c(2.0, 5))
   )
 )
-shiny::isolate(ds$get_filter_state())
-shiny::isolate(ds$get_call())
+isolate(ds$get_filter_state())
+isolate(ds$get_call())
 
 ## set_filter_state
 dataset <- DataframeFilteredDataset$new(iris, "iris")
@@ -30,7 +32,7 @@ fs <- teal_slices(
   teal_slice(dataname = "iris", varname = "Petal.Length", selected = c(2.0, 5))
 )
 dataset$set_filter_state(state = fs)
-shiny::isolate(dataset$get_filter_state())
+isolate(dataset$get_filter_state())
 
 }
 \keyword{internal}

--- a/man/DataframeFilteredDataset.Rd
+++ b/man/DataframeFilteredDataset.Rd
@@ -20,8 +20,8 @@ ds$set_filter_state(
     teal_slice(dataname = "iris", varname = "Petal.Length", selected = c(2.0, 5))
   )
 )
-isolate(ds$get_filter_state())
-isolate(ds$get_call())
+shiny::isolate(ds$get_filter_state())
+shiny::isolate(ds$get_call())
 
 ## set_filter_state
 dataset <- DataframeFilteredDataset$new(iris, "iris")
@@ -30,7 +30,7 @@ fs <- teal_slices(
   teal_slice(dataname = "iris", varname = "Petal.Length", selected = c(2.0, 5))
 )
 dataset$set_filter_state(state = fs)
-isolate(dataset$get_filter_state())
+shiny::isolate(dataset$get_filter_state())
 
 }
 \keyword{internal}

--- a/man/DateFilterState.Rd
+++ b/man/DateFilterState.Rd
@@ -13,12 +13,14 @@ include_css_files <- getFromNamespace("include_css_files", "teal.slice")
 include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 DateFilterState <- getFromNamespace("DateFilterState", "teal.slice")
 
+library(shiny)
+
 filter_state <- DateFilterState$new(
   x = c(Sys.Date() + seq(1:10), NA),
   slice = teal_slice(varname = "x", dataname = "data"),
   extract_type = character(0)
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(
     dataname = "data",
@@ -27,10 +29,9 @@ filter_state$set_state(
     keep_na = TRUE
   )
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 
 # working filter in an app
-library(shiny)
 library(shinyjs)
 
 dates <- c(Sys.Date() - 100, Sys.Date())

--- a/man/DateFilterState.Rd
+++ b/man/DateFilterState.Rd
@@ -18,7 +18,7 @@ filter_state <- DateFilterState$new(
   slice = teal_slice(varname = "x", dataname = "data"),
   extract_type = character(0)
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(
     dataname = "data",
@@ -27,9 +27,10 @@ filter_state$set_state(
     keep_na = TRUE
   )
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 
 # working filter in an app
+library(shiny)
 library(shinyjs)
 
 dates <- c(Sys.Date() - 100, Sys.Date())

--- a/man/DatetimeFilterState.Rd
+++ b/man/DatetimeFilterState.Rd
@@ -13,12 +13,14 @@ include_css_files <- getFromNamespace("include_css_files", "teal.slice")
 include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 DatetimeFilterState <- getFromNamespace("DatetimeFilterState", "teal.slice")
 
+library(shiny)
+
 filter_state <- DatetimeFilterState$new(
   x = c(Sys.time() + seq(0, by = 3600, length.out = 10), NA),
   slice = teal_slice(varname = "x", dataname = "data"),
   extract_type = character(0)
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(
     dataname = "data",
@@ -27,10 +29,9 @@ filter_state$set_state(
     keep_na = TRUE
   )
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 
 # working filter in an app
-library(shiny)
 library(shinyjs)
 
 datetimes <- as.POSIXct(c("2012-01-01 12:00:00", "2020-01-01 12:00:00"))

--- a/man/DatetimeFilterState.Rd
+++ b/man/DatetimeFilterState.Rd
@@ -18,7 +18,7 @@ filter_state <- DatetimeFilterState$new(
   slice = teal_slice(varname = "x", dataname = "data"),
   extract_type = character(0)
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(
     dataname = "data",
@@ -27,9 +27,10 @@ filter_state$set_state(
     keep_na = TRUE
   )
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 
 # working filter in an app
+library(shiny)
 library(shinyjs)
 
 datetimes <- as.POSIXct(c("2012-01-01 12:00:00", "2020-01-01 12:00:00"))

--- a/man/DefaultFilteredDataset.Rd
+++ b/man/DefaultFilteredDataset.Rd
@@ -11,9 +11,11 @@ Stores any object as inert entity. Filtering is not supported.
 # use non-exported function from teal.slice
 DefaultFilteredDataset <- getFromNamespace("DefaultFilteredDataset", "teal.slice")
 
+library(shiny)
+
 ds <- DefaultFilteredDataset$new(letters, "letters")
-shiny::isolate(ds$get_filter_state())
-shiny::isolate(ds$get_call())
+isolate(ds$get_filter_state())
+isolate(ds$get_call())
 
 }
 \keyword{internal}

--- a/man/DefaultFilteredDataset.Rd
+++ b/man/DefaultFilteredDataset.Rd
@@ -12,8 +12,8 @@ Stores any object as inert entity. Filtering is not supported.
 DefaultFilteredDataset <- getFromNamespace("DefaultFilteredDataset", "teal.slice")
 
 ds <- DefaultFilteredDataset$new(letters, "letters")
-isolate(ds$get_filter_state())
-isolate(ds$get_call())
+shiny::isolate(ds$get_filter_state())
+shiny::isolate(ds$get_call())
 
 }
 \keyword{internal}

--- a/man/EmptyFilterState.Rd
+++ b/man/EmptyFilterState.Rd
@@ -17,9 +17,9 @@ filter_state <- EmptyFilterState$new(
   slice = teal_slice(varname = "x", dataname = "data"),
   extract_type = character(0)
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 filter_state$set_state(teal_slice(dataname = "data", varname = "x", keep_na = TRUE))
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 
 }
 \keyword{internal}

--- a/man/EmptyFilterState.Rd
+++ b/man/EmptyFilterState.Rd
@@ -12,14 +12,16 @@
 include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 EmptyFilterState <- getFromNamespace("EmptyFilterState", "teal.slice")
 
+library(shiny)
+
 filter_state <- EmptyFilterState$new(
   x = NA,
   slice = teal_slice(varname = "x", dataname = "data"),
   extract_type = character(0)
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 filter_state$set_state(teal_slice(dataname = "data", varname = "x", keep_na = TRUE))
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 
 }
 \keyword{internal}

--- a/man/FilterPanelAPI.Rd
+++ b/man/FilterPanelAPI.Rd
@@ -20,7 +20,7 @@ fd <- init_filtered_data(list(iris = iris))
 fpa <- FilterPanelAPI$new(fd)
 
 # get the actual filter state --> empty named list
-isolate(fpa$get_filter_state())
+shiny::isolate(fpa$get_filter_state())
 
 # set a filter state
 set_filter_state(
@@ -31,13 +31,13 @@ set_filter_state(
 )
 
 # get the actual filter state --> named list with filters
-isolate(fpa$get_filter_state())
+shiny::isolate(fpa$get_filter_state())
 
 # remove all_filter_states
 fpa$clear_filter_states()
 
 # get the actual filter state --> empty named list
-isolate(fpa$get_filter_state())
+shiny::isolate(fpa$get_filter_state())
 
 }
 \section{Methods}{

--- a/man/FilterPanelAPI.Rd
+++ b/man/FilterPanelAPI.Rd
@@ -16,11 +16,13 @@ This class is supported by methods to set, get, remove filter states in the
 filter panel API.
 }
 \examples{
+library(shiny)
+
 fd <- init_filtered_data(list(iris = iris))
 fpa <- FilterPanelAPI$new(fd)
 
 # get the actual filter state --> empty named list
-shiny::isolate(fpa$get_filter_state())
+isolate(fpa$get_filter_state())
 
 # set a filter state
 set_filter_state(
@@ -31,13 +33,13 @@ set_filter_state(
 )
 
 # get the actual filter state --> named list with filters
-shiny::isolate(fpa$get_filter_state())
+isolate(fpa$get_filter_state())
 
 # remove all_filter_states
 fpa$clear_filter_states()
 
 # get the actual filter state --> empty named list
-shiny::isolate(fpa$get_filter_state())
+isolate(fpa$get_filter_state())
 
 }
 \section{Methods}{

--- a/man/FilterStateExpr.Rd
+++ b/man/FilterStateExpr.Rd
@@ -29,6 +29,7 @@ filter_state <- FilterStateExpr$new(
 filter_state$get_call()
 
 # working filter in an app
+library(shiny)
 library(shinyjs)
 
 ui <- fluidPage(

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -67,7 +67,7 @@ isolate(datasets$get_call("mtcars"))
 ### set_filter_state
 library(shiny)
 
-utils::data(miniACC, package = "MultiAssayExperiment")
+data(miniACC, package = "MultiAssayExperiment")
 datasets <- FilteredData$new(list(iris = iris, mae = miniACC))
 fs <- teal_slices(
   teal_slice(

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -51,15 +51,15 @@ datasets$datanames()
 datasets$set_filter_state(
   teal_slices(teal_slice(dataname = "iris", varname = "Species", selected = "virginica"))
 )
-isolate(datasets$get_call("iris"))
+shiny::isolate(datasets$get_call("iris"))
 
 datasets$set_filter_state(
   teal_slices(teal_slice(dataname = "mtcars", varname = "mpg", selected = c(15, 20)))
 )
 
-isolate(datasets$get_filter_state())
-isolate(datasets$get_call("iris"))
-isolate(datasets$get_call("mtcars"))
+shiny::isolate(datasets$get_filter_state())
+shiny::isolate(datasets$get_call("iris"))
+shiny::isolate(datasets$get_call("mtcars"))
 
 \dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 ### set_filter_state
@@ -87,7 +87,7 @@ fs <- teal_slices(
   )
 )
 datasets$set_filter_state(state = fs)
-isolate(datasets$get_filter_state())
+shiny::isolate(datasets$get_filter_state())
 \dontshow{\}) # examplesIf}
 }
 \keyword{internal}

--- a/man/FilteredData.Rd
+++ b/man/FilteredData.Rd
@@ -43,6 +43,8 @@ Common arguments are:
 # use non-exported function from teal.slice
 FilteredData <- getFromNamespace("FilteredData", "teal.slice")
 
+library(shiny)
+
 datasets <- FilteredData$new(list(iris = iris, mtcars = mtcars))
 
 # get datanames
@@ -51,18 +53,19 @@ datasets$datanames()
 datasets$set_filter_state(
   teal_slices(teal_slice(dataname = "iris", varname = "Species", selected = "virginica"))
 )
-shiny::isolate(datasets$get_call("iris"))
+isolate(datasets$get_call("iris"))
 
 datasets$set_filter_state(
   teal_slices(teal_slice(dataname = "mtcars", varname = "mpg", selected = c(15, 20)))
 )
 
-shiny::isolate(datasets$get_filter_state())
-shiny::isolate(datasets$get_call("iris"))
-shiny::isolate(datasets$get_call("mtcars"))
+isolate(datasets$get_filter_state())
+isolate(datasets$get_call("iris"))
+isolate(datasets$get_call("mtcars"))
 
 \dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 ### set_filter_state
+library(shiny)
 
 utils::data(miniACC, package = "MultiAssayExperiment")
 datasets <- FilteredData$new(list(iris = iris, mae = miniACC))
@@ -87,7 +90,7 @@ fs <- teal_slices(
   )
 )
 datasets$set_filter_state(state = fs)
-shiny::isolate(datasets$get_filter_state())
+isolate(datasets$get_filter_state())
 \dontshow{\}) # examplesIf}
 }
 \keyword{internal}

--- a/man/LogicalFilterState.Rd
+++ b/man/LogicalFilterState.Rd
@@ -13,18 +13,19 @@ include_css_files <- getFromNamespace("include_css_files", "teal.slice")
 include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 LogicalFilterState <- getFromNamespace("LogicalFilterState", "teal.slice")
 
+library(shiny)
+
 filter_state <- LogicalFilterState$new(
   x = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
   slice = teal_slice(varname = "x", dataname = "data")
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(dataname = "data", varname = "x", selected = TRUE, keep_na = TRUE)
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 
 # working filter in an app
-library(shiny)
 library(shinyjs)
 
 data_logical <- c(sample(c(TRUE, FALSE), 10, replace = TRUE), NA)

--- a/man/LogicalFilterState.Rd
+++ b/man/LogicalFilterState.Rd
@@ -13,18 +13,18 @@ include_css_files <- getFromNamespace("include_css_files", "teal.slice")
 include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 LogicalFilterState <- getFromNamespace("LogicalFilterState", "teal.slice")
 
-
 filter_state <- LogicalFilterState$new(
   x = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
   slice = teal_slice(varname = "x", dataname = "data")
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(dataname = "data", varname = "x", selected = TRUE, keep_na = TRUE)
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 
 # working filter in an app
+library(shiny)
 library(shinyjs)
 
 data_logical <- c(sample(c(TRUE, FALSE), 10, replace = TRUE), NA)

--- a/man/MAEFilteredDataset.Rd
+++ b/man/MAEFilteredDataset.Rd
@@ -31,7 +31,7 @@ fs <- teal_slices(
   )
 )
 dataset$set_filter_state(state = fs)
-isolate(dataset$get_filter_state())
+shiny::isolate(dataset$get_filter_state())
 \dontshow{\}) # examplesIf}
 }
 \keyword{internal}

--- a/man/MAEFilteredDataset.Rd
+++ b/man/MAEFilteredDataset.Rd
@@ -14,7 +14,7 @@
 # use non-exported function from teal.slice
 MAEFilteredDataset <- getFromNamespace("MAEFilteredDataset", "teal.slice")
 
-utils::data(miniACC, package = "MultiAssayExperiment")
+data(miniACC, package = "MultiAssayExperiment")
 dataset <- MAEFilteredDataset$new(miniACC, "MAE")
 fs <- teal_slices(
   teal_slice(
@@ -31,7 +31,9 @@ fs <- teal_slices(
   )
 )
 dataset$set_filter_state(state = fs)
-shiny::isolate(dataset$get_filter_state())
+
+library(shiny)
+isolate(dataset$get_filter_state())
 \dontshow{\}) # examplesIf}
 }
 \keyword{internal}

--- a/man/RangeFilterState.Rd
+++ b/man/RangeFilterState.Rd
@@ -13,11 +13,13 @@ include_css_files <- getFromNamespace("include_css_files", "teal.slice")
 include_js_files <- getFromNamespace("include_js_files", "teal.slice")
 RangeFilterState <- getFromNamespace("RangeFilterState", "teal.slice")
 
+library(shiny)
+
 filter_state <- RangeFilterState$new(
   x = c(NA, Inf, seq(1:10)),
   slice = teal_slice(varname = "x", dataname = "data")
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(
     dataname = "data",
@@ -27,10 +29,9 @@ filter_state$set_state(
     keep_inf = TRUE
   )
 )
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 
 # working filter in an app
-library(shiny)
 library(shinyjs)
 
 data_range <- c(runif(100, 0, 1), NA, Inf)

--- a/man/RangeFilterState.Rd
+++ b/man/RangeFilterState.Rd
@@ -17,7 +17,7 @@ filter_state <- RangeFilterState$new(
   x = c(NA, Inf, seq(1:10)),
   slice = teal_slice(varname = "x", dataname = "data")
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 filter_state$set_state(
   teal_slice(
     dataname = "data",
@@ -27,9 +27,10 @@ filter_state$set_state(
     keep_inf = TRUE
   )
 )
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
 
 # working filter in an app
+library(shiny)
 library(shinyjs)
 
 data_range <- c(runif(100, 0, 1), NA, Inf)

--- a/man/countBars.Rd
+++ b/man/countBars.Rd
@@ -58,6 +58,7 @@ labels <- countBars(
   countsnow = unname(counts)
 )
 
+library(shiny)
 
 ui <- fluidPage(
   div(

--- a/man/countBars.Rd
+++ b/man/countBars.Rd
@@ -49,6 +49,8 @@ include_css_files <- getFromNamespace("include_css_files", "teal.slice")
 countBars <- getFromNamespace("countBars", "teal.slice")
 updateCountBars <- getFromNamespace("updateCountBars", "teal.slice")
 
+library(shiny)
+
 choices <- sample(as.factor(c("a", "b", "c")), size = 20, replace = TRUE)
 counts <- table(choices)
 labels <- countBars(
@@ -57,8 +59,6 @@ labels <- countBars(
   countsmax = counts,
   countsnow = unname(counts)
 )
-
-library(shiny)
 
 ui <- fluidPage(
   div(

--- a/man/filter_state_api.Rd
+++ b/man/filter_state_api.Rd
@@ -79,8 +79,7 @@ clear_filter_states(datasets)
 \dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # Requires MultiAssayExperiment from Bioconductor
-library(MultiAssayExperiment)
-data(miniACC)
+data(miniACC, package = "MultiAssayExperiment")
 
 datasets <- init_filtered_data(list(mae = miniACC))
 fs <- teal_slices(

--- a/man/init_filter_state.Rd
+++ b/man/init_filter_state.Rd
@@ -46,9 +46,11 @@ Initializes a \code{FilterState} object corresponding to the class of the filter
 # use non-exported function from teal.slice
 init_filter_state <- getFromNamespace("init_filter_state", "teal.slice")
 
+library(shiny)
+
 filter_state <- init_filter_state(
   x = c(1:10, NA, Inf),
-  x_reactive = shiny::reactive(c(1:10, NA, Inf)),
+  x_reactive = reactive(c(1:10, NA, Inf)),
   slice = teal_slice(
     varname = "varname",
     dataname = "dataname"
@@ -56,25 +58,24 @@ filter_state <- init_filter_state(
   extract_type = "matrix"
 )
 
-shiny::isolate(filter_state$get_call())
+isolate(filter_state$get_call())
 
 # working filter in an app
-library(shiny)
 
 ui <- fluidPage(
   filter_state$ui(id = "app"),
-  shiny::verbatimTextOutput("call")
+  verbatimTextOutput("call")
 )
 server <- function(input, output, session) {
   filter_state$server("app")
 
-  output$call <- shiny::renderText(
+  output$call <- renderText(
     deparse1(filter_state$get_call(), collapse = "\n")
   )
 }
 
 if (interactive()) {
-  shiny::shinyApp(ui, server)
+  shinyApp(ui, server)
 }
 
 }

--- a/man/init_filter_state.Rd
+++ b/man/init_filter_state.Rd
@@ -48,7 +48,7 @@ init_filter_state <- getFromNamespace("init_filter_state", "teal.slice")
 
 filter_state <- init_filter_state(
   x = c(1:10, NA, Inf),
-  x_reactive = reactive(c(1:10, NA, Inf)),
+  x_reactive = shiny::reactive(c(1:10, NA, Inf)),
   slice = teal_slice(
     varname = "varname",
     dataname = "dataname"
@@ -56,22 +56,25 @@ filter_state <- init_filter_state(
   extract_type = "matrix"
 )
 
-isolate(filter_state$get_call())
+shiny::isolate(filter_state$get_call())
+
+# working filter in an app
+library(shiny)
 
 ui <- fluidPage(
   filter_state$ui(id = "app"),
-  verbatimTextOutput("call")
+  shiny::verbatimTextOutput("call")
 )
 server <- function(input, output, session) {
   filter_state$server("app")
 
-  output$call <- renderText(
+  output$call <- shiny::renderText(
     deparse1(filter_state$get_call(), collapse = "\n")
   )
 }
 
 if (interactive()) {
-  shinyApp(ui, server)
+  shiny::shinyApp(ui, server)
 }
 
 }

--- a/man/init_filter_states.Rd
+++ b/man/init_filter_states.Rd
@@ -53,6 +53,7 @@ rf <- init_filter_states(
   dataname = "DF"
 )
 
+library(shiny)
 ui <- fluidPage(
   actionButton("clear", span(icon("xmark"), "Remove all filters")),
   rf$ui_add(id = "add"),

--- a/man/init_filtered_dataset.Rd
+++ b/man/init_filtered_dataset.Rd
@@ -53,6 +53,8 @@ We recommend consulting the package maintainer before using it.
 
 \examples{
 # DataframeFilteredDataset example
+library(shiny)
+
 iris_fd <- init_filtered_dataset(iris, dataname = "iris")
 ui <- fluidPage(
   iris_fd$ui_add(id = "add"),
@@ -77,6 +79,8 @@ if (interactive()) {
 \dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # MAEFilteredDataset example
 library(MultiAssayExperiment)
+library(shiny)
+
 data(miniACC, package = "MultiAssayExperiment")
 
 MAE_fd <- init_filtered_dataset(miniACC, "MAE")

--- a/man/init_filtered_dataset.Rd
+++ b/man/init_filtered_dataset.Rd
@@ -78,7 +78,6 @@ if (interactive()) {
 
 \dontshow{if (requireNamespace("MultiAssayExperiment")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # MAEFilteredDataset example
-library(MultiAssayExperiment)
 library(shiny)
 
 data(miniACC, package = "MultiAssayExperiment")

--- a/man/toggle_button.Rd
+++ b/man/toggle_button.Rd
@@ -38,6 +38,7 @@ which may contain a child \verb{<i>} tag that specifies an icon to be displayed.
 # use non-exported function from teal.slice
 toggle_icon <- getFromNamespace("toggle_icon", "teal.slice")
 
+library(shiny)
 library(shinyjs)
 
 ui <- fluidPage(

--- a/tests/testthat/test-FilterStates.R
+++ b/tests/testthat/test-FilterStates.R
@@ -358,7 +358,7 @@ testthat::test_that("ui_add returns a message inside a div when data has no colu
   filter_states <- FilterStates$new(data = data.frame(), dataname = "iris")
   testthat::expect_identical(
     filter_states$ui_add("id"),
-    div("no sample variables available")
+    shiny::div("no sample variables available")
   )
 })
 

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -673,7 +673,7 @@ fs <- teal_slices(
   teal_slice(dataname = "iris", title = "test", id = "test", expr = "!is.na(Species)")
 )
 fs_rv <- reactiveVal(fs)
-datasets$set_available_teal_slices(reactive(fs_rv()))
+datasets$set_available_teal_slices(shiny::reactive(fs_rv()))
 datasets$set_filter_state(fs[1:2])
 shiny::testServer(
   datasets$srv_available_filters,

--- a/tests/testthat/test-FilteredData.R
+++ b/tests/testthat/test-FilteredData.R
@@ -672,7 +672,7 @@ fs <- teal_slices(
   teal_slice(dataname = "iris", varname = "Petal.Width", id = "duplicated"),
   teal_slice(dataname = "iris", title = "test", id = "test", expr = "!is.na(Species)")
 )
-fs_rv <- reactiveVal(fs)
+fs_rv <- shiny::reactiveVal(fs)
 datasets$set_available_teal_slices(shiny::reactive(fs_rv()))
 datasets$set_filter_state(fs[1:2])
 shiny::testServer(

--- a/tests/testthat/test-SEFilterStates.R
+++ b/tests/testthat/test-SEFilterStates.R
@@ -104,18 +104,18 @@ testthat::test_that("ui_add returns a message inside a div when data has no rows
   filter_states <- SEFilterStates$new(data = get_test_data(TRUE)[[1]], dataname = "test")
   testthat::expect_identical(
     filter_states$ui_add("id"),
-    div(
-      div("no sample variables available"),
-      div("no sample variables available")
+    shiny::div(
+      shiny::div("no sample variables available"),
+      shiny::div("no sample variables available")
     )
   )
 
   filter_states <- SEFilterStates$new(data = get_test_data(TRUE)[[2]], dataname = "test")
   testthat::expect_identical(
     filter_states$ui_add("id"),
-    div(
-      div("no samples available"),
-      div("no samples available")
+    shiny::div(
+      shiny::div("no samples available"),
+      shiny::div("no samples available")
     )
   )
 })

--- a/vignettes/filter-panel-for-developers.Rmd
+++ b/vignettes/filter-panel-for-developers.Rmd
@@ -163,6 +163,8 @@ to allow the user to add new filters.
 All the instructions herein can be utilized to build a `shiny` app.
 
 ```{r}
+library(shiny)
+
 # initializing FilteredData
 datasets <- init_filtered_data(list(iris = iris, mtcars = mtcars))
 

--- a/vignettes/teal-slice.Rmd
+++ b/vignettes/teal-slice.Rmd
@@ -62,8 +62,8 @@ The example below uses the `set_filter_state` function to set state and the stat
 For details please see the *Filter panel for developers* vignette.
 
 ```{r}
-library(teal.slice)
 library(shiny)
+library(teal.slice)
 
 # create a FilteredData object
 datasets <- init_filtered_data(list(iris = iris, mtcars = mtcars))

--- a/vignettes/teal-slice.Rmd
+++ b/vignettes/teal-slice.Rmd
@@ -63,6 +63,7 @@ For details please see the *Filter panel for developers* vignette.
 
 ```{r}
 library(teal.slice)
+library(shiny)
 
 # create a FilteredData object
 datasets <- init_filtered_data(list(iris = iris, mtcars = mtcars))


### PR DESCRIPTION
# Pull Request

- Fixes #529

ℹ️ Note: The package imports all functions from `{shiny}` via `@import shiny` {roxygen2} tag, however, there's a mixed bag of prefixed (`shiny::fun(...)`) and non-prefixed calls (`fun(...)`) in the (functions') code. ~~Those were not modified.~~ (see discussion)

#### Changes description

- Remove occurences of `shiny::` from `R/` code
- Moved `{shiny}` to Imports
- Replaced shiny functions in examples by
  - add `library(shiny)` when building a shiny app to run
  - ~~`fun` -> `shiny::fun` for others~~
- Corrects vignettes accordingly