### PR TITLE
docs hotfix

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -30,7 +30,6 @@ check_simple_name <- function(name) {
 #' as needed. Thus, we do not export this method.
 #'
 #' @param pattern (`character`) pattern of files to be included, passed to `system.file`
-#' @param except (`character`) vector of basename filenames to be excluded
 #'
 #' @return HTML code that includes `JS` files
 #' @keywords internal
@@ -41,7 +40,7 @@ include_js_files <- function(pattern) {
     pattern = pattern,
     full.names = TRUE
   )
-  return(singleton(lapply(js_files, includeScript)))
+  singleton(lapply(js_files, includeScript))
 }
 
 #' Build concatenating call

--- a/man/include_js_files.Rd
+++ b/man/include_js_files.Rd
@@ -8,8 +8,6 @@ include_js_files(pattern)
 }
 \arguments{
 \item{pattern}{(\code{character}) pattern of files to be included, passed to \code{system.file}}
-
-\item{except}{(\code{character}) vector of basename filenames to be excluded}
 }
 \value{
 HTML code that includes \code{JS} files


### PR DESCRIPTION
Removed unused argument from documentation.
Removed stray explicit `return` statement.