### PR TITLE
Forces exact match on attribute to avoid problems

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 
 ### Bug fixes
 
-* Performs an exact match on `init_filtered_dataset` when determining the default label of a dataset.
+* Performs an exact match when determining the default label of a dataset from attributes.
 
 ### Miscellaneous
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,10 @@
 * `set_filter_state` no longer accepts a nested list. Use `teal_slices()` and `teal_slice()` instead.
 * Renamed `FilteredDataset` subclass that handles `data.frame`s from `DefaultFilteredDataset` to `DataframeFilteredDataset`. Added new class `DefaultFilteredDataset` that will store any type of object. Filtering will is not supported.
 
+### Bug fixes
+
+* Performs an exact match on `init_filtered_dataset` when determining the default label of a dataset.
+
 ### Miscellaneous
 
 * Specified minimal version of package dependencies.

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -96,7 +96,7 @@ FilterState <- R6::R6Class( # nolint
       if (is.null(isolate(slice$keep_na)) && anyNA(x)) slice$keep_na <- TRUE
       private$teal_slice <- slice
       # Obtain variable label.
-      varlabel <- attr(x, "label")
+      varlabel <- attr(x, "label", exact = TRUE)
       # Display only when different from varname.
       private$varlabel <-
         if (is.null(varlabel) || identical(varlabel, private$get_varname())) {

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -159,7 +159,7 @@ ChoicesFilterState <- R6::R6Class( # nolint
         x_factor <- if (!is.factor(x)) {
           structure(
             factor(as.character(x), levels = as.character(sort(unique(x)))),
-            label = attr(x, "label")
+            label = attr(x, "label", exact = TRUE)
           )
         } else {
           x

--- a/R/FilteredDataset-utils.R
+++ b/R/FilteredDataset-utils.R
@@ -82,25 +82,25 @@
 #' }
 #' @keywords internal
 #' @export
-init_filtered_dataset <- function(dataset, # nolint
+init_filtered_dataset <- function(dataset,
                                   dataname,
                                   keys = character(0),
                                   parent_name = character(0),
                                   parent = reactive(dataset),
                                   join_keys = character(0),
-                                  label = attr(dataset, "label")) {
+                                  label = attr(dataset, "label", exact = TRUE)) {
   UseMethod("init_filtered_dataset")
 }
 
 #' @keywords internal
 #' @export
-init_filtered_dataset.data.frame <- function(dataset, # nolint
+init_filtered_dataset.data.frame <- function(dataset,
                                              dataname,
                                              keys = character(0),
                                              parent_name = character(0),
                                              parent = NULL,
                                              join_keys = character(0),
-                                             label = attr(dataset, "label")) {
+                                             label = attr(dataset, "label", exact = TRUE)) {
   DataframeFilteredDataset$new(
     dataset = dataset,
     dataname = dataname,
@@ -114,13 +114,13 @@ init_filtered_dataset.data.frame <- function(dataset, # nolint
 
 #' @keywords internal
 #' @export
-init_filtered_dataset.MultiAssayExperiment <- function(dataset, # nolint
+init_filtered_dataset.MultiAssayExperiment <- function(dataset,
                                                        dataname,
                                                        keys = character(0),
                                                        parent_name, # ignored
                                                        parent, # ignored
                                                        join_keys, # ignored
-                                                       label = attr(dataset, "label")) {
+                                                       label = attr(dataset, "label", exact = TRUE)) {
   if (!requireNamespace("MultiAssayExperiment", quietly = TRUE)) {
     stop("Cannot load MultiAssayExperiment - please install the package or restart your session.")
   }
@@ -134,13 +134,13 @@ init_filtered_dataset.MultiAssayExperiment <- function(dataset, # nolint
 
 #' @keywords internal
 #' @export
-init_filtered_dataset.default <- function(dataset, # nolint
+init_filtered_dataset.default <- function(dataset,
                                           dataname,
                                           keys, # ignored
                                           parent_name, # ignored
                                           parent, # ignored
                                           join_keys, # ignored
-                                          label = attr(dataset, "label")) {
+                                          label = attr(dataset, "label", exact = TRUE)) {
   DefaultFilteredDataset$new(
     dataset = dataset,
     dataname = dataname,

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -29,7 +29,7 @@ FilteredDataset <- R6::R6Class( # nolint
     #'
     #' @return Object of class `FilteredDataset`, invisibly.
     #'
-    initialize = function(dataset, dataname, keys = character(0), label = attr(dataset, "label")) {
+    initialize = function(dataset, dataname, keys = character(0), label = attr(dataset, "label", exact = TRUE)) {
       logger::log_trace("Instantiating { class(self)[1] }, dataname: { dataname }")
 
       # dataset assertion in child classes

--- a/man/FilteredDataset.Rd
+++ b/man/FilteredDataset.Rd
@@ -45,7 +45,7 @@ Initializes this \code{FilteredDataset} object.
   dataset,
   dataname,
   keys = character(0),
-  label = attr(dataset, "label")
+  label = attr(dataset, "label", exact = TRUE)
 )}\if{html}{\out{</div>}}
 }
 

--- a/man/init_filtered_dataset.Rd
+++ b/man/init_filtered_dataset.Rd
@@ -11,7 +11,7 @@ init_filtered_dataset(
   parent_name = character(0),
   parent = reactive(dataset),
   join_keys = character(0),
-  label = attr(dataset, "label")
+  label = attr(dataset, "label", exact = TRUE)
 )
 }
 \arguments{


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #560

### Changes description

- Made the change on `init_filtered_dataset` S3 methods
- Made the change on other places that are determining the label from attributes
- Removes apparent unused `# nolint` hint (passes locally)
  - `{lintr}` must be smart enough to detect that there's a generic on the same file and now allows for function names with more than 30 characters