### PR TITLE
209 modify filter card css when expanded

### DIFF
--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -255,7 +255,7 @@ a.remove_all:hover {
 .filter-card:has(> .filter-card-header[aria-expanded="true"]) {
   transition-property: box-shadow, background-color;
   transition-duration: 150ms;
-  box-shadow: 0 0 5px 2px rgb(0 0 0 / 20%);
+  box-shadow: 0 0 5px 2px #00000033;
   background-color: #ffffffb8;
 }
 

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -278,6 +278,12 @@ a.remove_all:hover {
   background-color: var(--bs-gray-200, #e9ecef);
 }
 
+.filter-card-header[aria-expanded="true"]:hover {
+  transition-property: background-color;
+  transition-duration: 150ms;
+  background-color: #f5f5f5;
+}
+
 .filter-card-title {
   display: flex;
   flex-direction: row;

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -253,10 +253,15 @@ a.remove_all:hover {
 }
 
 .filter-card:has(> .filter-card-header[aria-expanded="true"]) {
-  transition-property: box-shadow, background-color;
+  transition-property: background-color;
+  transition-duration: 150ms;
+  background-color: #ffffffb8;
+}
+
+.filter-card:has(> .filter-card-header[aria-expanded="true"]):hover {
+  transition-property: box-shadow;
   transition-duration: 150ms;
   box-shadow: 0 0 5px 2px #00000033;
-  background-color: #ffffffb8;
 }
 
 .filter-card-header {

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -255,13 +255,13 @@ a.remove_all:hover {
 .filter-card:has(> .filter-card-header[aria-expanded="true"]) {
   transition-property: background-color;
   transition-duration: 150ms;
-  background-color: #ffffffb8;
+  background-color: var(--bs-gray-100, #f8f9fa);
 }
 
 .filter-card:has(> .filter-card-header[aria-expanded="true"]):hover {
   transition-property: box-shadow;
   transition-duration: 150ms;
-  box-shadow: 0 0 5px 2px #00000033;
+  box-shadow: 0 0 5px 2px var(--bs-gray-800, #343a40);
 }
 
 .filter-card-header {
@@ -286,7 +286,7 @@ a.remove_all:hover {
 .filter-card-header[aria-expanded="true"]:hover {
   transition-property: background-color;
   transition-duration: 150ms;
-  background-color: #f5f5f5;
+  background-color: var(--bs-gray-100, #f8f9fa);
 }
 
 .filter-card-title {

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -252,6 +252,13 @@ a.remove_all:hover {
   margin: 0em;
 }
 
+.filter-card:has(> .filter-card-header[aria-expanded="true"]) {
+  transition-property: box-shadow, background-color;
+  transition-duration: 150ms;
+  box-shadow: 0 0 5px 2px rgb(0 0 0 / 20%);
+  background-color: #ffffffb8;
+}
+
 .filter-card-header {
   color: var(--bs-body-color, #333333);
   padding: 5px 10px;
@@ -267,8 +274,7 @@ a.remove_all:hover {
   border-bottom-right-radius: 0;
 }
 
-.filter-card-header:hover,
-.filter-card-body:hover {
+.filter-card-header:hover {
   background-color: var(--bs-gray-200, #e9ecef);
 }
 


### PR DESCRIPTION
Closes #209 

Added `boxshadow` property to and brightened background color in expanded filter card.
Selector uses the `aria-expanded` property rather than class names because it works in all BS versions and initiates `transition` immediately on click rather than after the card has been expanded.

![image](https://github.com/insightsengineering/teal.slice/assets/114988527/ff325d13-c20e-4e6a-9f73-c50c7e49a360)