### PR TITLE
335 bring `teal_slice` and `teal_slices` to package INDEX

### DIFF
--- a/R/teal_slice.R
+++ b/R/teal_slice.R
@@ -110,6 +110,36 @@
 #'
 #' @seealso [`teal_slices`]
 #'
+#' @usage
+#' teal_slice(
+#'   dataname,
+#'   varname,
+#'   id,
+#'   expr,
+#'   choices = NULL,
+#'   selected = NULL,
+#'   keep_na = NULL,
+#'   keep_inf = NULL,
+#'   fixed = FALSE,
+#'   anchored = FALSE,
+#'   multiple = TRUE,
+#'   title = NULL,
+#'   ...
+#' )
+#'
+#' is.teal_slice(x)
+#'
+#' as.teal_slice(x)
+#'
+#' # S3 method for class 'teal_slice'
+#' as.list.teal_slice(x, ...)
+#'
+#' # S3 method for class 'teal_slice'
+#' format.teal_slice(show_all = FALSE, trim_lines = TRUE, ...)
+#'
+#' # S3 method for class 'teal_slice'
+#' print.teal_slice(x, ...)
+#'
 #' @export
 teal_slice <- function(dataname,
                        varname,
@@ -172,7 +202,6 @@ teal_slice <- function(dataname,
   ans
 }
 
-#' @rdname teal_slice
 #' @export
 #' @keywords internal
 #'
@@ -180,7 +209,6 @@ is.teal_slice <- function(x) { # nolint
   inherits(x, "teal_slice")
 }
 
-#' @rdname teal_slice
 #' @export
 #' @keywords internal
 #'
@@ -189,7 +217,6 @@ as.teal_slice <- function(x) { # nolint
   do.call(teal_slice, x)
 }
 
-#' @rdname teal_slice
 #' @export
 #' @keywords internal
 #'
@@ -208,8 +235,6 @@ as.list.teal_slice <- function(x, ...) {
   x[c(formal_args, extra_args)]
 }
 
-
-#' @rdname teal_slice
 #' @export
 #' @keywords internal
 #'
@@ -223,14 +248,12 @@ format.teal_slice <- function(x, show_all = FALSE, trim_lines = TRUE, ...) {
   jsonify(x_list, trim_lines)
 }
 
-#' @rdname teal_slice
 #' @export
 #' @keywords internal
 #'
 print.teal_slice <- function(x, ...) {
   cat(format(x, ...))
 }
-
 
 # format utils -----
 

--- a/man/teal_slice.Rd
+++ b/man/teal_slice.Rd
@@ -2,11 +2,6 @@
 % Please edit documentation in R/teal_slice.R
 \name{teal_slice}
 \alias{teal_slice}
-\alias{is.teal_slice}
-\alias{as.teal_slice}
-\alias{as.list.teal_slice}
-\alias{format.teal_slice}
-\alias{print.teal_slice}
 \title{Specify single filter}
 \usage{
 teal_slice(
@@ -29,11 +24,14 @@ is.teal_slice(x)
 
 as.teal_slice(x)
 
-\method{as.list}{teal_slice}(x, ...)
+# S3 method for class 'teal_slice'
+as.list.teal_slice(x, ...)
 
-\method{format}{teal_slice}(x, show_all = FALSE, trim_lines = TRUE, ...)
+# S3 method for class 'teal_slice'
+format.teal_slice(show_all = FALSE, trim_lines = TRUE, ...)
 
-\method{print}{teal_slice}(x, ...)
+# S3 method for class 'teal_slice'
+print.teal_slice(x, ...)
 }
 \arguments{
 \item{dataname}{(\code{character(1)}) name of data set}
@@ -171,4 +169,3 @@ print(x1, show_all = TRUE, trim_lines = FALSE)
 \seealso{
 \code{\link{teal_slices}}
 }
-\keyword{internal}


### PR DESCRIPTION
Proposition on how to solve #335

- Removed `@rdname teal_slice` from utility functions for `teal_slice` 
- Created customized `@usage` section to display both `teal_slice` and utility functions on the same page
- Result: `teal_slice` appearing in package index, where utility functions only appear in `teal_slice` documentation page

If this is acceptable, I will do the same for `teal_slices`

<img width="946" alt="index" src="https://github.com/insightsengineering/teal.slice/assets/133694481/d1b3f113-a099-4486-a603-bd8cfdd0c44e">
<img width="935" alt="documentation" src="https://github.com/insightsengineering/teal.slice/assets/133694481/e07b5fce-61b5-4c82-bcd7-fde2bd2fe9f9">
