### PR TITLE
add rmarkdown to the Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Suggests:
     knitr (>= 1.42),
     MultiAssayExperiment,
     SummarizedExperiment,
+    rmarkdown (>= 2.19),
     testthat (>= 3.1.5),
     withr (>= 2.1.0)
 VignetteBuilder:
@@ -69,7 +70,7 @@ Config/Needs/verdepcheck: rstudio/shiny, rstudio/bslib, mllg/checkmate,
     daattali/shinyjs, dreamRs/shinyWidgets, insightsengineering/teal.data,
     insightsengineering/teal.logger, insightsengineering/teal.widgets,
     yihui/knitr, bioc::MultiAssayExperiment, bioc::SummarizedExperiment,
-    r-lib/testthat, r-lib/withr
+    rstudio/rmarkdown, r-lib/testthat, r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
fix verdepcheck pipeline: https://github.com/insightsengineering/teal.slice/actions/runs/8585974107

added `rmarkdown` back as per https://github.com/insightsengineering/teal.logger/pull/49#issuecomment-1735586602

verdepcheck pipeline will be manually triggered. You can check its status here: https://github.com/insightsengineering/teal.slice/actions/workflows/scheduled.yaml?query=branch%3Afix_verdepcheck