### PR TITLE
Fix filtering of ordered column

### DIFF
--- a/tests/testthat/test-ChoicesFilterState.R
+++ b/tests/testthat/test-ChoicesFilterState.R
@@ -104,7 +104,7 @@ testthat::test_that("get_call returns call always if choices are limited - regar
   )
   testthat::expect_identical(
     shiny::isolate(filter_state$get_call()),
-    NULL
+    quote(var %in% c("a", "b", "c"))
   )
 })
 
@@ -176,6 +176,17 @@ testthat::test_that("get_call returns calls appropriate for factor var", {
   )
 })
 
+testthat::test_that("get_call returns calls appropriate for factor var", {
+  filter_state <- ChoicesFilterState$new(
+    x = ordered(facts),
+    slice = teal_slice(dataname = "data", varname = "var", selected = facts[1])
+  )
+  testthat::expect_identical(
+    shiny::isolate(filter_state$get_call()),
+    quote(var == "item1")
+  )
+})
+
 testthat::test_that("get_call returns calls appropriate for numeric var", {
   filter_state <- ChoicesFilterState$new(
     nums,
@@ -219,6 +230,7 @@ testthat::test_that("get_call returns calls appropriate for posixlt var", {
     quote(var == as.POSIXlt("2000-01-01 12:00:00", tz = "GMT"))
   )
 })
+
 
 # set_state ----
 testthat::test_that("set_state raises warning when selection not within allowed choices", {

--- a/tests/testthat/test-MAEFilteredDataset.R
+++ b/tests/testthat/test-MAEFilteredDataset.R
@@ -125,7 +125,7 @@ testthat::test_that("get_call returns a call with applying filter", {
         miniacc <- MultiAssayExperiment::subsetByColData(
           miniacc,
           miniacc$years_to_birth >= 30 & miniacc$years_to_birth <= 50 &
-            miniacc$vital_status == 1L & miniacc$gender == "female"
+            miniacc$vital_status == 1 & miniacc$gender == "female"
         )
       ),
       RPPAArray = quote(
@@ -208,7 +208,7 @@ testthat::test_that(
           miniacc <- MultiAssayExperiment::subsetByColData( # nolint
             miniacc,
             miniacc$years_to_birth >= 30 & miniacc$years_to_birth <= 50 &
-              miniacc$vital_status == 1L &
+              miniacc$vital_status == 1 &
               miniacc$gender == "female"
           )
         ),


### PR DESCRIPTION
Fixes #575 

<details>
<summary>Example app</summary>

```r
library(teal)
library(shiny)
library(scda)

ADSL <- synthetic_cdisc_data("latest")$adsl
ADSL$empty <- NA
ADSL$logical1 <- FALSE
ADSL$logical <- sample(c(TRUE, FALSE), size = nrow(ADSL), replace = TRUE)
ADSL$numeric <- rnorm(nrow(ADSL))
ADSL$numeric_categorical <- sample(1:3, size = nrow(ADSL), replace = TRUE)
ADSL$categorical <- sample(letters[1:10], size = nrow(ADSL), replace = TRUE)
ADSL$ordered <- ordered(sample(letters[1:10], size = nrow(ADSL), replace = TRUE))
ADSL$date <- Sys.Date() + seq_len(nrow(ADSL))
ADSL$datetime <- Sys.time() + seq_len(nrow(ADSL)) * 3600 * 12

ADSL$numeric[sample(1:nrow(ADSL), size = 10, )] <- NA
ADSL$numeric[sample(1:nrow(ADSL), size = 10, )] <- Inf
ADSL$numeric[sample(1:nrow(ADSL), size = 10, )] <- NA
ADSL$logical[sample(1:nrow(ADSL), size = 10, )] <- NA
ADSL$date[sample(1:nrow(ADSL), size = 10, )] <- NA
ADSL$datetime[sample(1:nrow(ADSL), size = 10, )] <- NA
ADSL$categorical[sample(1:nrow(ADSL), size = 10, )] <- NA

ADTTE <- synthetic_cdisc_data("latest")$adtte
ADRS <- synthetic_cdisc_data("latest")$adrs


app <- init(
  data = teal_data(ADSL = ADSL, ADTTE = ADTTE, ADRS = ADRS),
  modules = list(example_module()),
  filter = teal_slices(
    teal_slice("ADSL", "empty"),
    teal_slice("ADSL", "logical1"),
    teal_slice("ADSL", "logical"),
    teal_slice("ADSL", "numeric"),
    teal_slice("ADSL", "numeric_categorical"),
    teal_slice("ADSL", "categorical"),
    teal_slice("ADSL", "ordered"),
    teal_slice("ADSL", "date"),
    teal_slice("ADSL", "datetime")
  )
)

runApp(app)

```

</details>