### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     MultiAssayExperiment,
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     SummarizedExperiment,
     testthat (>= 3.1.5),
     withr (>= 2.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     shinyWidgets (>= 0.6.2),
     teal.data (>= 0.4.0),
     teal.logger (>= 0.1.3.9013),
-    teal.widgets (>= 0.4.0),
+    teal.widgets (>= 0.4.2),
     utils
 Suggests:
     knitr (>= 1.42),


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.