### PR TITLE
Reduce unwanted reactivity on filter panel changes

### DIFF
--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -730,7 +730,7 @@ FilterStates <- R6::R6Class( # nolint
             # create a new FilterState
             fstate <- init_filter_state(
               x = data[, slice$varname, drop = TRUE],
-              # data_reactive is a function which eventually calls get_call(sid).
+              # data_reactive is a function which eventually depends on the reactiveVal reactive_call().
               # This chain of calls returns column from the data filtered by everything
               # but filter identified by the sid argument. FilterState then get x_reactive
               # and this no longer needs to be a function to pass sid. reactive in the FilterState

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -42,6 +42,7 @@ FilteredDataset <- R6::R6Class( # nolint
       private$dataname <- dataname
       private$keys <- keys
       private$label <- if (is.null(label)) character(0) else label
+      private$reactive_call <- reactiveVal()
 
       # function executing reactive call and returning data
       private$data_filtered_fun <- function(sid = "") {
@@ -53,7 +54,7 @@ FilteredDataset <- R6::R6Class( # nolint
         }
         env <- new.env(parent = parent.env(globalenv()))
         env[[dataname]] <- private$dataset
-        filter_call <- self$get_call(sid)
+        filter_call <- private$reactive_call()
         eval_expr_with_msg(filter_call, env)
         get(x = dataname, envir = env)
       }
@@ -301,6 +302,10 @@ FilteredDataset <- R6::R6Class( # nolint
             }
           )
 
+          observeEvent(self$get_call(), ignoreNULL = FALSE, {
+            private$reactive_call(self$get_call())
+          })
+
           observeEvent(self$get_filter_state(), {
             shinyjs::hide("filter_count_ui")
             shinyjs::show("filters")
@@ -374,6 +379,7 @@ FilteredDataset <- R6::R6Class( # nolint
     dataname = character(0),
     keys = character(0),
     label = character(0),
+    reactive_call = NULL, # reactiveVal
 
     # Adds `FilterStates` to the `private$filter_states`.
     # `FilterStates` is added once for each element of the dataset.

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -44,10 +44,6 @@ FilteredDataset <- R6::R6Class( # nolint
       private$label <- if (is.null(label)) character(0) else label
       private$reactive_call <- reactiveVal()
 
-      observeEvent(self$get_call(), ignoreNULL = FALSE, {
-        private$reactive_call(self$get_call())
-      })
-
       # function executing reactive call and returning data
       private$data_filtered_fun <- function(sid = "") {
         checkmate::assert_character(sid)
@@ -305,6 +301,10 @@ FilteredDataset <- R6::R6Class( # nolint
               private$get_filter_states()[[x]]$srv_active(id = x)
             }
           )
+
+          observeEvent(self$get_call(), ignoreNULL = FALSE, {
+            private$reactive_call(self$get_call())
+          })
 
           observeEvent(self$get_filter_state(), {
             shinyjs::hide("filter_count_ui")

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -44,6 +44,10 @@ FilteredDataset <- R6::R6Class( # nolint
       private$label <- if (is.null(label)) character(0) else label
       private$reactive_call <- reactiveVal()
 
+      observeEvent(self$get_call(), ignoreNULL = FALSE, {
+        private$reactive_call(self$get_call())
+      })
+
       # function executing reactive call and returning data
       private$data_filtered_fun <- function(sid = "") {
         checkmate::assert_character(sid)
@@ -301,10 +305,6 @@ FilteredDataset <- R6::R6Class( # nolint
               private$get_filter_states()[[x]]$srv_active(id = x)
             }
           )
-
-          observeEvent(self$get_call(), ignoreNULL = FALSE, {
-            private$reactive_call(self$get_call())
-          })
 
           observeEvent(self$get_filter_state(), {
             shinyjs::hide("filter_count_ui")

--- a/R/FilteredDatasetDataframe.R
+++ b/R/FilteredDatasetDataframe.R
@@ -89,7 +89,7 @@ DataframeFilteredDataset <- R6::R6Class( # nolint
           env <- new.env(parent = parent.env(globalenv()))
           env[[dataname]] <- private$dataset
           env[[parent_name]] <- parent()
-          filter_call <- self$get_call(sid)
+          filter_call <- private$reactive_call()
           eval_expr_with_msg(filter_call, env)
           get(x = dataname, envir = env)
         }


### PR DESCRIPTION
Closes #62 

Pending things before it can be undrafted:
1. Make the `private$reactive_call` for a given `sid`. Right now it will not work when `sid` is provided. A possible solution is to make the `sid` a private object and use it inside the server logic.
2. Figure out the right place to observe `self$get_call()` to extract the call.
3. Test for normal `data.frame`. `CDISC` `data.frame` and `MAE` object.

Example app to test:

```r
library(shiny)
library(teal.data)
pkgload::load_all("teal.slice")

datasets <- init_filtered_data(
  list(
    iris = iris,
    ADSL = rADSL, ADAE = rADAE,
    MAE = hermes::multi_assay_experiment
  ),
  join_keys = default_cdisc_join_keys[c("ADSL", "ADAE")]
)

ui <- fluidPage(
  fluidRow(
    column(
      width = 9,
      DT::DTOutput("iris_table"),
      DT::DTOutput("adsl_table"),
      DT::DTOutput("adae_table"),
      shiny::verbatimTextOutput("mae_text")
    ),
    column(width = 3, datasets$ui_filter_panel("filter_panel"))
  )
)

server <- function(input, output, session) {
  datasets$srv_filter_panel("filter_panel")
  iris_filtered_data <- reactive(datasets$get_data(dataname = "iris", filtered = TRUE))
  adsl_filtered_data <- reactive(datasets$get_data(dataname = "ADSL", filtered = TRUE))
  adae_filtered_data <- reactive(datasets$get_data(dataname = "ADAE", filtered = TRUE))
  mae_filtered_data <- reactive(datasets$get_data(dataname = "MAE", filtered = TRUE))

  observeEvent(iris_filtered_data(), {
    print("IRIS changed!!!")
  })
  observeEvent(adsl_filtered_data(), {
    print("ADSL changed!!!")
  })
  observeEvent(adae_filtered_data(), {
    print("ADAE changed!!!")
  })
  observeEvent(mae_filtered_data(), {
    print("MAE changed!!!")
  })
  output$iris_table <- DT::renderDT(head(iris_filtered_data()))
  output$adsl_table <- DT::renderDT(head(adsl_filtered_data()))
  output$adae_table <- DT::renderDT(head(adae_filtered_data()))
  output$mae_text <- renderPrint({
    mae_filtered_data()
  })
}

shinyApp(ui, server)
```