### PR TITLE
revert `logger::log_shiny_input_changes`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,6 @@
 ### Bug fixes
 * Fix error while creating the filter choices when the data has a factor with a level containing an empty string ("").
 
-### Enhancements
-* Added `logger` functionality for logging changes in shiny inputs. `logger` was added to Imports.
-
 # teal.slice 0.5.1
 
 ### Bug fixes

--- a/R/FilterState.R
+++ b/R/FilterState.R
@@ -207,7 +207,6 @@ FilterState <- R6::R6Class( # nolint
         id = id,
         function(input, output, session) {
           logger::log_trace("FilterState$server initializing module for slice: { private$get_id() } ")
-          if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
           private$server_summary("summary")
           if (private$is_fixed()) {
             private$server_inputs_fixed("inputs")
@@ -746,7 +745,6 @@ FilterState <- R6::R6Class( # nolint
     # @return `NULL`, invisibly.
     keep_na_srv = function(id) {
       moduleServer(id, function(input, output, session) {
-        if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
         # 1. renderUI is used here as an observer which triggers only if output is visible
         #  and if the reactive changes - reactive triggers only if the output is visible.
         # 2. We want to trigger change of the labels only if reactive count changes (not underlying data)

--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -412,7 +412,6 @@ ChoicesFilterState <- R6::R6Class( # nolint
         id = id,
         function(input, output, session) {
           logger::log_trace("ChoicesFilterState$server_inputs initializing, id: { private$get_id() }")
-          if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
 
           # 1. renderUI is used here as an observer which triggers only if output is visible
           #  and if the reactive changes - reactive triggers only if the output is visible.

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -323,7 +323,6 @@ DateFilterState <- R6::R6Class( # nolint
         id = id,
         function(input, output, session) {
           logger::log_trace("DateFilterState$server initializing, id: { private$get_id() }")
-          if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
 
           # this observer is needed in the situation when teal_slice$selected has been
           # changed directly by the api - then it's needed to rerender UI element

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -385,7 +385,6 @@ DatetimeFilterState <- R6::R6Class( # nolint
         id = id,
         function(input, output, session) {
           logger::log_trace("DatetimeFilterState$server initializing, id: { private$get_id() }")
-          if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
           # this observer is needed in the situation when teal_slice$selected has been
           # changed directly by the api - then it's needed to rerender UI element
           # to show relevant values

--- a/R/FilterStateExpr.R
+++ b/R/FilterStateExpr.R
@@ -168,7 +168,6 @@ FilterStateExpr <- R6::R6Class( # nolint
       moduleServer(
         id = id,
         function(input, output, session) {
-          if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
           private$server_summary("summary")
 
           private$destroy_shiny <- function() {

--- a/R/FilterStateLogical.R
+++ b/R/FilterStateLogical.R
@@ -297,7 +297,6 @@ LogicalFilterState <- R6::R6Class( # nolint
           non_missing_values <- reactive(Filter(Negate(is.na), private$x_reactive()))
           output$trigger_visible <- renderUI({
             logger::log_trace("LogicalFilterState$server@1 updating count labels, id: { private$get_id() }")
-            if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
 
             countsnow <- if (!is.null(private$x_reactive())) {
               unname(table(factor(non_missing_values(), levels = private$get_choices())))

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -692,7 +692,6 @@ RangeFilterState <- R6::R6Class( # nolint
     # @return `NULL`.
     keep_inf_srv = function(id) {
       moduleServer(id, function(input, output, session) {
-        if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
         # 1. renderUI is used here as an observer which triggers only if output is visible
         #  and if the reactive changes - reactive triggers only if the output is visible.
         # 2. We want to trigger change of the labels only if reactive count changes (not underlying data)

--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -431,7 +431,6 @@ FilterStates <- R6::R6Class( # nolint
         id = id,
         function(input, output, session) {
           logger::log_trace("FilterStates$srv_add initializing, dataname: { private$dataname }")
-          if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
 
           # available choices to display
           avail_column_choices <- reactive({

--- a/R/FilterStatesSE.R
+++ b/R/FilterStatesSE.R
@@ -157,7 +157,6 @@ SEFilterStates <- R6::R6Class( # nolint
         id = id,
         function(input, output, session) {
           logger::log_trace("SEFilterState$srv_add initializing, dataname: { private$dataname }")
-          if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
 
           row_data <- SummarizedExperiment::rowData(data)
           col_data <- SummarizedExperiment::colData(data)

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -606,7 +606,6 @@ FilteredData <- R6::R6Class( # nolint
       checkmate::assert_function(active_datanames)
       moduleServer(id, function(input, output, session) {
         logger::log_trace("FilteredData$srv_active initializing")
-        if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
 
         private$srv_available_filters("available_filters")
 
@@ -718,7 +717,6 @@ FilteredData <- R6::R6Class( # nolint
       checkmate::assert_class(active_datanames, "reactive")
       moduleServer(id, function(input, output, session) {
         logger::log_trace("FilteredData$srv_add initializing")
-        if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
         observeEvent(input$minimise_filter_add_vars, {
           shinyjs::toggle("filter_add_vars_contents")
           toggle_icon(session$ns("minimise_filter_add_vars"), c("fa-angle-right", "fa-angle-down"))
@@ -810,7 +808,6 @@ FilteredData <- R6::R6Class( # nolint
         id = id,
         function(input, output, session) {
           logger::log_trace("FilteredData$srv_filter_overview initializing")
-          if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
 
           observeEvent(input$minimise_filter_overview, {
             shinyjs::toggle("filters_overview_contents")
@@ -992,7 +989,6 @@ FilteredData <- R6::R6Class( # nolint
     # the appropriate filter state id.
     srv_available_filters = function(id) {
       moduleServer(id, function(input, output, session) {
-        if (shiny::isRunning()) logger::log_shiny_input_changes(input, namespace = "teal.slice")
         slices_available <- self$get_available_teal_slices()
         slices_interactive <- reactive(
           Filter(function(slice) isFALSE(slice$fixed), slices_available())


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/553