### PR TITLE
Removes 'plotly_relayout' warning from console

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,4 +76,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/FilterStateRange.R
+++ b/R/FilterStateRange.R
@@ -488,13 +488,21 @@ RangeFilterState <- R6::R6Class( # nolint
           # Prepare for histogram construction.
           plot_data <- c(private$plot_data, source = session$ns("histogram_plot"))
 
+          trigger_event_data <- reactiveVal(NULL)
+
           # Display histogram, adding a second trace that contains filtered data.
           output$plot <- plotly::renderPlotly({
             histogram <- do.call(plotly::plot_ly, plot_data)
             histogram <- do.call(plotly::layout, c(list(p = histogram), private$plot_layout()))
             histogram <- do.call(plotly::config, c(list(p = histogram), private$plot_config()))
             histogram <- do.call(plotly::add_histogram, c(list(p = histogram), private$plot_filtered()))
+            trigger_event_data(TRUE)
             histogram
+          })
+
+          relayout_data <- reactive({
+            req(trigger_event_data())
+            plotly::event_data("plotly_relayout", source = session$ns("histogram_plot"))
           })
 
           # Dragging shapes (lines) on plot updates selection.
@@ -502,10 +510,10 @@ RangeFilterState <- R6::R6Class( # nolint
             observeEvent(
               ignoreNULL = FALSE,
               ignoreInit = TRUE,
-              eventExpr = plotly::event_data("plotly_relayout", source = session$ns("histogram_plot")),
+              eventExpr = relayout_data(),
               handlerExpr = {
                 logger::log_trace("RangeFilterState$server@1 selection changed, id: { private$get_id() }")
-                event <- plotly::event_data("plotly_relayout", source = session$ns("histogram_plot"))
+                event <- relayout_data()
                 if (any(grepl("shapes", names(event)))) {
                   line_positions <- private$get_selected()
                   if (any(grepl("shapes[0]", names(event), fixed = TRUE))) {


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #600

### Changes description

- Only call `event_data` after histogram is plotted.

How to test:

- Run he app below and notice that there aren't any warnings. Both at start but on every addition of a range filter.

Warning that is no longer visible

```r
#> Listening on http://127.0.0.1:7089
#> Warning: The 'plotly_relayout' event tied a source ID of 'teal-main_ui-filter_panel-active-new_iris-filter-new_iris_Sepal_Length-inputs-histogram_plot' is not registered. In order to obtain this event data, please add `event_register(p, 'plotly_relayout')` to the plot (`p`) that you wish to obtain event data from.
```

App

```r
pkgload::load_all(teal.slice)
library(teal)

options(teal.log_level = "INFO")

app <- init(
  data = teal_data(
    new_iris = transform(iris, id = seq_len(nrow(iris))),
    new_mtcars = transform(mtcars, id = seq_len(nrow(mtcars))),
    code = "
      new_iris <- transform(iris, id = seq_len(nrow(iris)))
      new_mtcars <- transform(mtcars, id = seq_len(nrow(mtcars)))
    "
  ),
  modules = module(
    label = "data source",
    server = function(input, output, session, data) {},
    ui = function(id, ...) tags$div(p("information about data source")),
    datanames = "all"
  ),
  filter = teal_slices(
    teal_slice(dataname = "new_iris", varname = "Sepal.Length")
  ),
  title = "App title",
  header = tags$h1("Sample App"),
  footer = tags$p("Copyright 2017 - 2023")
) |> shiny::runApp()
```