### PR TITLE
update min version of testthat and precommit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
           - shinycssloaders
           - shinyjs
           - shinyWidgets
+          - insightsengineering/teal.code
           - insightsengineering/teal.data
           - insightsengineering/teal.logger
           - insightsengineering/teal.widgets

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Suggests:
     MultiAssayExperiment,
     rmarkdown (>= 2.23),
     SummarizedExperiment,
-    testthat (>= 3.1.5),
+    testthat (>= 3.1.8),
     withr (>= 2.1.0)
 VignetteBuilder:
     knitr,


### PR DESCRIPTION
Similar with https://github.com/insightsengineering/teal.code/pull/220, failure in min_isolated pipeline:
https://github.com/insightsengineering/teal.slice/actions/runs/11537362432/job/32114685586#step:9:1346

### Summary:

* Update testthat minimum version due to usage of `testthat::it()` in DESCRIPTION file:
https://github.com/insightsengineering/teal.slice/blob/main/tests/testthat/test-utils.R#L9

* Add `teal.code` to the pre-commit configuration to allow it to use the development version when running. This is necessary because the development version of `teal.data` requires the development version of `teal.code` to run, and without this, the pre-commit will fail.

