### PR TITLE
Fix windows build in r-universe

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -84,7 +84,7 @@ make_c_call <- function(choices) {
 sanitize_id <- function(id) {
   pattern_escape <- "[^0-9A-Za-z_]"
 
-  id_new <- gsub(pattern_escape, "_", id)
+  id_new <- gsub(pattern_escape, "_", id, perl = TRUE)
   hashes <- vapply(id[id != id_new], rlang::hash, character(1), USE.NAMES = FALSE)
 
   id[id != id_new] <- paste0("h", substr(hashes, 1, 4), "_", id_new[id != id_new])


### PR DESCRIPTION
Fixes the [package build in windows](https://github.com/r-universe/pharmaverse/actions/runs/12161651762/job/33917098250) due to test failure.

### Root cause
Non-Perl compatible regex was causing different behavior when Unicode text was used as id for the namespace.

As far as I know using perl compatible regex is recommended for complex regex (like using lookbehind) or when dealing with unicode characters, the only advantage of non-perl compatible regex is that it performs better and we do not have a performance issue in our case as we're dealing with a small vector of texts.

#### Windows reprex 🐛
``` r
pattern_escape <- "[^0-9A-Za-z_]"
id <- "\U5F4AA"
gsub(pattern_escape, "_", id, perl = FALSE)
#> [1] "__"
gsub(pattern_escape, "_", id, perl = TRUE)
#> [1] "_"
```

<sup>Created on 2024-12-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

#### Linux reprex 👌
``` r
pattern_escape <- "[^0-9A-Za-z_]"
id <- "\U5F4AA"
gsub(pattern_escape, "_", id, perl = FALSE)
#> [1] "_"
gsub(pattern_escape, "_", id, perl = TRUE)
#> [1] "_"
```

<sup>Created on 2024-12-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

#### macOS reprex 👌
``` r
pattern_escape <- "[^0-9A-Za-z_]"
id <- "\U1F4AA"
gsub(pattern_escape, "_", id, perl = FALSE)
#> [1] "_"
gsub(pattern_escape, "_", id, perl = TRUE)
#> [1] "_"
```

<sup>Created on 2024-12-10 with [reprex v2.1.0](https://reprex.tidyverse.org/)</sup>
