### PR TITLE
Fix `scheduled` inputs

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -28,18 +28,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-strategy: ["min_cohort", "min_isolated", "release", "max"]
+        pair:
+          - { test-strategy: "min_cohort", repos: "" }
+          - { test-strategy: "min_isolated", repos: "" }
+          - { test-strategy: "release", repos: "" }
+          - { test-strategy: "max", repos: "https://pharmaverse.r-universe.dev" }
     uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@main
-    name: Dependency Test - ${{ matrix.test-strategy }} 🔢
+    name: Dependency Test - ${{ matrix.pair.test-strategy }} 🔢
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
       GCHAT_WEBHOOK: ${{ secrets.GCHAT_WEBHOOK }}
     with:
-      strategy: ${{ matrix.test-strategy }}
+      strategy: ${{ matrix.pair.test-strategy }}
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
-      extra-deps: |
-        insightsengineering/teal.code
+      additional-repos: ${{ matrix.pair.repos }}
   branch-cleanup:
     if: >
       github.event_name == 'schedule' || (

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,7 +71,7 @@ Config/Needs/verdepcheck: rstudio/shiny, rstudio/bslib, mllg/checkmate,
     daroczig/logger, plotly/plotly, r-lib/R6, daattali/shinycssloaders,
     daattali/shinyjs, dreamRs/shinyWidgets, insightsengineering/teal.data,
     insightsengineering/teal.logger, insightsengineering/teal.widgets,
-    yihui/knitr, bioc::MultiAssayExperiment, bioc::SummarizedExperiment, bioc::MatrixGenerics,
+    yihui/knitr, bioc::MultiAssayExperiment, bioc::SummarizedExperiment,
     rstudio/rmarkdown, r-lib/testthat, r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,9 +56,9 @@ Imports:
     utils
 Suggests:
     knitr (>= 1.42),
-    MultiAssayExperiment,
+    MultiAssayExperiment (>= 1.32.0),
     rmarkdown (>= 2.23),
-    SummarizedExperiment,
+    SummarizedExperiment (>= 1.36.0),
     testthat (>= 3.1.8),
     withr (>= 2.1.0)
 VignetteBuilder:
@@ -71,7 +71,7 @@ Config/Needs/verdepcheck: rstudio/shiny, rstudio/bslib, mllg/checkmate,
     daroczig/logger, plotly/plotly, r-lib/R6, daattali/shinycssloaders,
     daattali/shinyjs, dreamRs/shinyWidgets, insightsengineering/teal.data,
     insightsengineering/teal.logger, insightsengineering/teal.widgets,
-    yihui/knitr, bioc::MultiAssayExperiment, bioc::SummarizedExperiment,
+    yihui/knitr, bioc::MultiAssayExperiment, bioc::SummarizedExperiment, bioc::MatrixGenerics,
     rstudio/rmarkdown, r-lib/testthat, r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8


### PR DESCRIPTION
Part of https://github.com/insightsengineering/nestdevs-tasks/issues/98

`extra-deps` was badly formed