### PR TITLE
Support more MAE and SE versions in CI Pipelines

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -43,6 +43,8 @@ jobs:
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
       additional-repos: ${{ matrix.pair.repos }}
+      extra-deps: |
+        matrixStats (>= 1.5.0)
   branch-cleanup:
     if: >
       github.event_name == 'schedule' || (

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,11 +56,11 @@ Imports:
     utils
 Suggests:
     knitr (>= 1.42),
-    MultiAssayExperiment (>= 1.32.0),
+    MultiAssayExperiment,
     rmarkdown (>= 2.23),
-    SummarizedExperiment (>= 1.36.0),
-    testthat (>= 3.1.8),
-    withr (>= 2.1.0)
+    SummarizedExperiment,
+    testthat (>= 3.2.2),
+    withr (>= 3.0.2)
 VignetteBuilder:
     knitr,
     rmarkdown
@@ -72,7 +72,7 @@ Config/Needs/verdepcheck: rstudio/shiny, rstudio/bslib, mllg/checkmate,
     daattali/shinyjs, dreamRs/shinyWidgets, insightsengineering/teal.data,
     insightsengineering/teal.logger, insightsengineering/teal.widgets,
     yihui/knitr, bioc::MultiAssayExperiment, bioc::SummarizedExperiment,
-    rstudio/rmarkdown, r-lib/testthat, r-lib/withr
+    rstudio/rmarkdown, r-lib/testthat, r-lib/withr, bioc::matrixStats
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
A follow-up after https://github.com/insightsengineering/teal.slice/pull/634 that allows to use older MAE and SE versions