### PR TITLE
Should we vbump teal.data ?

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Imports:
     shinycssloaders (>= 1.0.0),
     shinyjs,
     shinyWidgets (>= 0.6.2),
-    teal.data (>= 0.4.0),
+    teal.data (>= 0.7.0),
     teal.logger (>= 0.3.1),
     teal.widgets (>= 0.4.2),
     utils


### PR DESCRIPTION
Need to rethink if we need to vbump teal.data for teal.slice. Currently it supports few older versions (starting from 0.4.0.)