### PR TITLE
Don't display dataset in the filter panel if:

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -549,7 +549,7 @@ FilteredData <- R6::R6Class( # nolint
                     isolate(active_datanames()),
                     function(dataname) {
                       fdataset <- private$get_filtered_dataset(dataname)
-                      fdataset$ui_active(id = ns(dataname), allow_add = private$allow_add)
+                      fdataset$ui_active(id = ns(dataname))
                     }
                   )
                 )

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -204,86 +204,85 @@ FilteredDataset <- R6::R6Class( # nolint
     ui_active = function(id, allow_add = TRUE) {
       dataname <- self$get_dataname()
       checkmate::assert_string(dataname)
-
       ns <- NS(id)
-      if_multiple_filter_states <- length(private$get_filter_states()) > 1
-      tags$span(
-        id = id,
-        class = "teal-slice",
-        include_css_files("filter-panel"),
-        include_js_files(pattern = "icons"),
-        bslib::accordion(
-          id = ns("dataset_filter_accordian"),
-          class = "teal-slice-dataset-filter",
-          bslib::accordion_panel(
-            dataname,
-            style = "padding: 0; margin: 0;",
-            bslib::page_fluid(
-              id = ns("whole_ui"),
-              style = "margin: 0; padding: 0;",
-              uiOutput(ns("active_filter_badge")),
-              div(
-                id = ns("filter_util_icons"),
-                class = "teal-slice filter-util-icons",
+      if (allow_add || length(self$get_filter_state())) {
+        tags$span(
+          id = id,
+          class = "teal-slice",
+          include_css_files("filter-panel"),
+          include_js_files(pattern = "icons"),
+          bslib::accordion(
+            id = ns("dataset_filter_accordian"),
+            class = "teal-slice-dataset-filter",
+            bslib::accordion_panel(
+              dataname,
+              style = "padding: 0; margin: 0;",
+              bslib::page_fluid(
+                id = ns("whole_ui"),
+                style = "margin: 0; padding: 0;",
+                uiOutput(ns("active_filter_badge")),
                 if (allow_add) {
-                  tags$a(
-                    class = "teal-slice filter-icon",
-                    tags$i(
-                      id = ns("add_filter_icon"),
-                      class = "fa fa-plus",
-                      title = "fold/expand transform panel",
-                      onclick = sprintf(
-                        "togglePanelItems(this, '%s', 'fa-plus', 'fa-minus');
+                  div(
+                    id = ns("filter_util_icons"),
+                    class = "teal-slice filter-util-icons",
+                    tags$a(
+                      class = "teal-slice filter-icon",
+                      tags$i(
+                        id = ns("add_filter_icon"),
+                        class = "fa fa-plus",
+                        title = "fold/expand transform panel",
+                        onclick = sprintf(
+                          "togglePanelItems(this, '%s', 'fa-plus', 'fa-minus');
                         if ($(this).hasClass('fa-minus')) {
                           $('#%s .accordion-button.collapsed').click();
                         }",
-                        ns("add_panel"),
-                        ns("dataset_filter_accordian")
+                          ns("add_panel"),
+                          ns("dataset_filter_accordian")
+                        )
                       )
+                    ),
+                    uiOutput(ns("remove_filters_ui"))
+                  )
+                },
+                if (allow_add) {
+                  bslib::page_fluid(
+                    style = "padding: 0px 15px 0px 15px; margin: 0;",
+                    tags$div(
+                      id = ns("add_panel"),
+                      class = "add-panel",
+                      style = "display: none;",
+                      self$ui_add(ns(private$dataname))
                     )
                   )
                 },
-                uiOutput(ns("remove_filters_ui"))
-              ),
-              bslib::page_fluid(
-                style = "padding: 0px 15px 0px 15px; margin: 0;",
-                if (allow_add) {
-                  tags$div(
-                    id = ns("add_panel"),
-                    class = "add-panel",
-                    style = "display: none;",
-                    self$ui_add(ns(private$dataname))
+                tags$div(
+                  id = ns("filter_count_ui"),
+                  style = "display: none;",
+                  tagList(
+                    textOutput(ns("filter_count"))
                   )
-                }
-              ),
-              tags$div(
-                id = ns("filter_count_ui"),
-                style = "display: none;",
-                tagList(
-                  textOutput(ns("filter_count"))
-                )
-              ),
-              tags$div(
-                # id needed to insert and remove UI to filter single variable as needed
-                # it is currently also used by the above module to entirely hide this panel
-                id = ns("filters"),
-                class = "parent-hideable-list-group",
-                tagList(
-                  lapply(
-                    names(private$get_filter_states()),
-                    function(x) {
-                      tagList(private$get_filter_states()[[x]]$ui_active(id = ns(x)))
-                    }
+                ),
+                tags$div(
+                  # id needed to insert and remove UI to filter single variable as needed
+                  # it is currently also used by the above module to entirely hide this panel
+                  id = ns("filters"),
+                  class = "parent-hideable-list-group",
+                  tagList(
+                    lapply(
+                      names(private$get_filter_states()),
+                      function(x) {
+                        tagList(private$get_filter_states()[[x]]$ui_active(id = ns(x)))
+                      }
+                    )
                   )
                 )
               )
             )
-          )
-        ),
-        tags$script(
-          HTML(
-            sprintf(
-              "
+          ),
+          tags$script(
+            HTML(
+              sprintf(
+                "
             $(document).ready(function() {
               $('#%s').appendTo('#%s > .accordion-item > .accordion-header');
               $('#%s > .accordion-item > .accordion-header').css({
@@ -292,15 +291,16 @@ FilteredDataset <- R6::R6Class( # nolint
               $('#%s').appendTo('#%s .accordion-header .accordion-title');
             });
           ",
-              ns("filter_util_icons"),
-              ns("dataset_filter_accordian"),
-              ns("dataset_filter_accordian"),
-              ns("active_filter_badge"),
-              ns("dataset_filter_accordian")
+                ns("filter_util_icons"),
+                ns("dataset_filter_accordian"),
+                ns("dataset_filter_accordian"),
+                ns("active_filter_badge"),
+                ns("dataset_filter_accordian")
+              )
             )
           )
         )
-      )
+      }
     },
 
     #' @description

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -202,87 +202,88 @@ FilteredDataset <- R6::R6Class( # nolint
     #'
     #' @return `shiny.tag`
     ui_active = function(id, allow_add = TRUE) {
-      dataname <- self$get_dataname()
-      checkmate::assert_string(dataname)
-      ns <- NS(id)
-      if (allow_add || length(self$get_filter_state())) {
-        tags$span(
-          id = id,
-          class = "teal-slice",
-          include_css_files("filter-panel"),
-          include_js_files(pattern = "icons"),
-          bslib::accordion(
-            id = ns("dataset_filter_accordian"),
-            class = "teal-slice-dataset-filter",
-            bslib::accordion_panel(
-              dataname,
-              style = "padding: 0; margin: 0;",
-              bslib::page_fluid(
-                id = ns("whole_ui"),
-                style = "margin: 0; padding: 0;",
-                uiOutput(ns("active_filter_badge")),
-                if (allow_add) {
-                  div(
-                    id = ns("filter_util_icons"),
-                    class = "teal-slice filter-util-icons",
-                    tags$a(
-                      class = "teal-slice filter-icon",
-                      tags$i(
-                        id = ns("add_filter_icon"),
-                        class = "fa fa-plus",
-                        title = "fold/expand transform panel",
-                        onclick = sprintf(
-                          "togglePanelItems(this, '%s', 'fa-plus', 'fa-minus');
+      isolate({
+        dataname <- self$get_dataname()
+        checkmate::assert_string(dataname)
+        ns <- NS(id)
+        if (allow_add || length(self$get_filter_state())) {
+          tags$span(
+            id = id,
+            class = "teal-slice",
+            include_css_files("filter-panel"),
+            include_js_files(pattern = "icons"),
+            bslib::accordion(
+              id = ns("dataset_filter_accordian"),
+              class = "teal-slice-dataset-filter",
+              bslib::accordion_panel(
+                dataname,
+                style = "padding: 0; margin: 0;",
+                bslib::page_fluid(
+                  id = ns("whole_ui"),
+                  style = "margin: 0; padding: 0;",
+                  uiOutput(ns("active_filter_badge")),
+                  if (allow_add) {
+                    div(
+                      id = ns("filter_util_icons"),
+                      class = "teal-slice filter-util-icons",
+                      tags$a(
+                        class = "teal-slice filter-icon",
+                        tags$i(
+                          id = ns("add_filter_icon"),
+                          class = "fa fa-plus",
+                          title = "fold/expand transform panel",
+                          onclick = sprintf(
+                            "togglePanelItems(this, '%s', 'fa-plus', 'fa-minus');
                         if ($(this).hasClass('fa-minus')) {
                           $('#%s .accordion-button.collapsed').click();
                         }",
-                          ns("add_panel"),
-                          ns("dataset_filter_accordian")
+                            ns("add_panel"),
+                            ns("dataset_filter_accordian")
+                          )
                         )
-                      )
-                    ),
-                    uiOutput(ns("remove_filters_ui"))
-                  )
-                },
-                if (allow_add) {
-                  bslib::page_fluid(
-                    style = "padding: 0px 15px 0px 15px; margin: 0;",
-                    tags$div(
-                      id = ns("add_panel"),
-                      class = "add-panel",
-                      style = "display: none;",
-                      self$ui_add(ns(private$dataname))
+                      ),
+                      uiOutput(ns("remove_filters_ui"))
                     )
-                  )
-                },
-                tags$div(
-                  id = ns("filter_count_ui"),
-                  style = "display: none;",
-                  tagList(
-                    textOutput(ns("filter_count"))
-                  )
-                ),
-                tags$div(
-                  # id needed to insert and remove UI to filter single variable as needed
-                  # it is currently also used by the above module to entirely hide this panel
-                  id = ns("filters"),
-                  class = "parent-hideable-list-group",
-                  tagList(
-                    lapply(
-                      names(private$get_filter_states()),
-                      function(x) {
-                        tagList(private$get_filter_states()[[x]]$ui_active(id = ns(x)))
-                      }
+                  },
+                  if (allow_add) {
+                    bslib::page_fluid(
+                      style = "padding: 0px 15px 0px 15px; margin: 0;",
+                      tags$div(
+                        id = ns("add_panel"),
+                        class = "add-panel",
+                        style = "display: none;",
+                        self$ui_add(ns(private$dataname))
+                      )
+                    )
+                  },
+                  tags$div(
+                    id = ns("filter_count_ui"),
+                    style = "display: none;",
+                    tagList(
+                      textOutput(ns("filter_count"))
+                    )
+                  ),
+                  tags$div(
+                    # id needed to insert and remove UI to filter single variable as needed
+                    # it is currently also used by the above module to entirely hide this panel
+                    id = ns("filters"),
+                    class = "parent-hideable-list-group",
+                    tagList(
+                      lapply(
+                        names(private$get_filter_states()),
+                        function(x) {
+                          tagList(private$get_filter_states()[[x]]$ui_active(id = ns(x)))
+                        }
+                      )
                     )
                   )
                 )
               )
-            )
-          ),
-          tags$script(
-            HTML(
-              sprintf(
-                "
+            ),
+            tags$script(
+              HTML(
+                sprintf(
+                  "
             $(document).ready(function() {
               $('#%s').appendTo('#%s > .accordion-item > .accordion-header');
               $('#%s > .accordion-item > .accordion-header').css({
@@ -291,16 +292,17 @@ FilteredDataset <- R6::R6Class( # nolint
               $('#%s').appendTo('#%s .accordion-header .accordion-title');
             });
           ",
-                ns("filter_util_icons"),
-                ns("dataset_filter_accordian"),
-                ns("dataset_filter_accordian"),
-                ns("active_filter_badge"),
-                ns("dataset_filter_accordian")
+                  ns("filter_util_icons"),
+                  ns("dataset_filter_accordian"),
+                  ns("dataset_filter_accordian"),
+                  ns("active_filter_badge"),
+                  ns("dataset_filter_accordian")
+                )
               )
             )
           )
-        )
-      }
+        }
+      })
     },
 
     #' @description
@@ -308,8 +310,10 @@ FilteredDataset <- R6::R6Class( # nolint
     #'
     #' @param id (`character(1)`)
     #'   `shiny` module instance id.
+    #' @param allow_add (`logical(1)`)
+    #'   logical flag specifying whether the user will be able to add new filters
     #' @return `NULL`.
-    srv_active = function(id) {
+    srv_active = function(id, allow_add = TRUE) {
       moduleServer(
         id = id,
         function(input, output, session) {

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -207,12 +207,8 @@ FilteredDataset <- R6::R6Class( # nolint
     #'
     #' @return `shiny.tag`
     ui_active = function(id) {
-      isolate({
-        dataname <- self$get_dataname()
-        checkmate::assert_string(dataname)
-        ns <- NS(id)
-        uiOutput(ns("container"))
-      })
+      ns <- NS(id)
+      uiOutput(ns("container"))
     },
     #' @description
     #' Server module for a dataset active filters.
@@ -226,11 +222,8 @@ FilteredDataset <- R6::R6Class( # nolint
         function(input, output, session) {
           dataname <- self$get_dataname()
           logger::log_debug("FilteredDataset$srv_active initializing, dataname: { dataname }")
-          checkmate::assert_string(dataname)
 
-          filter_count <- reactive({
-            length(self$get_filter_state())
-          })
+          filter_count <- reactive(length(self$get_filter_state()))
 
           is_displayed <- reactiveVal()
           private$session_bindings[[session$ns("is_displayed")]] <- observe({

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -34,6 +34,7 @@ FilteredDataset <- R6::R6Class( # nolint
       logger::log_debug("Instantiating { class(self)[1] }, dataname: { dataname }")
       checkmate::assert_character(keys, any.missing = FALSE)
       checkmate::assert_character(label, null.ok = TRUE)
+      private$allow_add <- reactiveVal(TRUE)
       private$dataset <- dataset
       private$dataname <- dataname
       private$keys <- keys
@@ -143,7 +144,13 @@ FilteredDataset <- R6::R6Class( # nolint
     #' @return Virtual method, returns nothing and raises error.
     #'
     set_filter_state = function(state) {
-      stop("set_filter_state is an abstract class method.")
+      isolate({
+        allow_add <- attr(state, "allow_add")
+        if (!is.null(allow_add) && !identical(allow_add, private$allow_add())) {
+          private$allow_add(allow_add)
+        }
+        invisible(self)
+      })
     },
 
     #' @description
@@ -197,123 +204,23 @@ FilteredDataset <- R6::R6Class( # nolint
     #' `shiny` module containing active filters for a dataset, along with a title and a remove button.
     #' @param id (`character(1)`)
     #'   `shiny` module instance id.
-    #' @param allow_add (`logical(1)`)
-    #'   logical flag specifying whether the user will be able to add new filters
     #'
     #' @return `shiny.tag`
-    ui_active = function(id, allow_add = TRUE) {
+    ui_active = function(id) {
       isolate({
         dataname <- self$get_dataname()
         checkmate::assert_string(dataname)
         ns <- NS(id)
-        if (allow_add || length(self$get_filter_state())) {
-          tags$span(
-            id = id,
-            class = "teal-slice",
-            include_css_files("filter-panel"),
-            include_js_files(pattern = "icons"),
-            bslib::accordion(
-              id = ns("dataset_filter_accordian"),
-              class = "teal-slice-dataset-filter",
-              bslib::accordion_panel(
-                dataname,
-                style = "padding: 0; margin: 0;",
-                bslib::page_fluid(
-                  id = ns("whole_ui"),
-                  style = "margin: 0; padding: 0;",
-                  uiOutput(ns("active_filter_badge")),
-                  if (allow_add) {
-                    div(
-                      id = ns("filter_util_icons"),
-                      class = "teal-slice filter-util-icons",
-                      tags$a(
-                        class = "teal-slice filter-icon",
-                        tags$i(
-                          id = ns("add_filter_icon"),
-                          class = "fa fa-plus",
-                          title = "fold/expand transform panel",
-                          onclick = sprintf(
-                            "togglePanelItems(this, '%s', 'fa-plus', 'fa-minus');
-                        if ($(this).hasClass('fa-minus')) {
-                          $('#%s .accordion-button.collapsed').click();
-                        }",
-                            ns("add_panel"),
-                            ns("dataset_filter_accordian")
-                          )
-                        )
-                      ),
-                      uiOutput(ns("remove_filters_ui"))
-                    )
-                  },
-                  if (allow_add) {
-                    bslib::page_fluid(
-                      style = "padding: 0px 15px 0px 15px; margin: 0;",
-                      tags$div(
-                        id = ns("add_panel"),
-                        class = "add-panel",
-                        style = "display: none;",
-                        self$ui_add(ns(private$dataname))
-                      )
-                    )
-                  },
-                  tags$div(
-                    id = ns("filter_count_ui"),
-                    style = "display: none;",
-                    tagList(
-                      textOutput(ns("filter_count"))
-                    )
-                  ),
-                  tags$div(
-                    # id needed to insert and remove UI to filter single variable as needed
-                    # it is currently also used by the above module to entirely hide this panel
-                    id = ns("filters"),
-                    class = "parent-hideable-list-group",
-                    tagList(
-                      lapply(
-                        names(private$get_filter_states()),
-                        function(x) {
-                          tagList(private$get_filter_states()[[x]]$ui_active(id = ns(x)))
-                        }
-                      )
-                    )
-                  )
-                )
-              )
-            ),
-            tags$script(
-              HTML(
-                sprintf(
-                  "
-            $(document).ready(function() {
-              $('#%s').appendTo('#%s > .accordion-item > .accordion-header');
-              $('#%s > .accordion-item > .accordion-header').css({
-                'display': 'flex'
-              });
-              $('#%s').appendTo('#%s .accordion-header .accordion-title');
-            });
-          ",
-                  ns("filter_util_icons"),
-                  ns("dataset_filter_accordian"),
-                  ns("dataset_filter_accordian"),
-                  ns("active_filter_badge"),
-                  ns("dataset_filter_accordian")
-                )
-              )
-            )
-          )
-        }
+        uiOutput(ns("container"))
       })
     },
-
     #' @description
     #' Server module for a dataset active filters.
     #'
     #' @param id (`character(1)`)
     #'   `shiny` module instance id.
-    #' @param allow_add (`logical(1)`)
-    #'   logical flag specifying whether the user will be able to add new filters
     #' @return `NULL`.
-    srv_active = function(id, allow_add = TRUE) {
+    srv_active = function(id) {
       moduleServer(
         id = id,
         function(input, output, session) {
@@ -323,6 +230,91 @@ FilteredDataset <- R6::R6Class( # nolint
 
           filter_count <- reactive({
             length(self$get_filter_state())
+          })
+
+          is_displayed <- reactiveVal()
+          private$session_bindings[[session$ns("is_displayed")]] <- observe({
+            res <- private$allow_add() || filter_count() > 0
+            isolate(
+              if (!identical(res, is_displayed())) is_displayed(res)
+            )
+          })
+
+          output$container <- renderUI({
+            if (is_displayed()) {
+              isolate({
+                tags$span(
+                  id = id,
+                  class = "teal-slice",
+                  include_css_files("filter-panel"),
+                  include_js_files(pattern = "icons"),
+                  bslib::accordion(
+                    id = session$ns("dataset_filter_accordian"),
+                    class = "teal-slice-dataset-filter",
+                    bslib::accordion_panel(
+                      dataname,
+                      style = "padding: 0; margin: 0;",
+                      bslib::page_fluid(
+                        id = session$ns("whole_ui"),
+                        style = "margin: 0; padding: 0;",
+                        uiOutput(session$ns("active_filter_badge")),
+                        uiOutput(session$ns("filter_util_icons")),
+                        bslib::page_fluid(
+                          style = "padding: 0px 15px 0px 15px; margin: 0;",
+                          tags$div(
+                            id = session$ns("add_panel"),
+                            class = "add-panel",
+                            style = "display: none;",
+                            self$ui_add(session$ns(private$dataname))
+                          )
+                        ),
+                        tags$div(
+                          id = session$ns("filter_count_ui"),
+                          style = "display: none;",
+                          tagList(
+                            textOutput(session$ns("filter_count"))
+                          )
+                        ),
+                        tags$div(
+                          # id needed to insert and remove UI to filter single variable as needed
+                          # it is currently also used by the above module to entirely hide this panel
+                          id = session$ns("filters"),
+                          class = "parent-hideable-list-group",
+                          tagList(
+                            lapply(
+                              names(private$get_filter_states()),
+                              function(x) {
+                                tagList(private$get_filter_states()[[x]]$ui_active(id = session$ns(x)))
+                              }
+                            )
+                          )
+                        )
+                      )
+                    )
+                  ),
+                  tags$script(
+                    HTML(
+                      sprintf(
+                        "
+            $(document).ready(function() {
+              $('#%s').appendTo('#%s > .accordion-item > .accordion-header');
+              $('#%s > .accordion-item > .accordion-header').css({
+                'display': 'flex'
+              });
+              $('#%s').appendTo('#%s .accordion-header .accordion-title');
+            });
+          ",
+                        session$ns("filter_util_icons"),
+                        session$ns("dataset_filter_accordian"),
+                        session$ns("dataset_filter_accordian"),
+                        session$ns("active_filter_badge"),
+                        session$ns("dataset_filter_accordian")
+                      )
+                    )
+                  )
+                )
+              })
+            }
           })
 
           output$active_filter_badge <- renderUI({
@@ -343,6 +335,41 @@ FilteredDataset <- R6::R6Class( # nolint
             )
           )
 
+          output$filter_util_icons <- renderUI({
+            if (private$allow_add()) {
+              div(
+                class = "teal-slice filter-util-icons",
+                tags$a(
+                  class = "teal-slice filter-icon",
+                  tags$i(
+                    id = session$ns("add_filter_icon"),
+                    class = "fa fa-plus",
+                    title = "fold/expand transform panel",
+                    onclick = sprintf(
+                      "togglePanelItems(this, '%s', 'fa-plus', 'fa-minus');
+                      if ($(this).hasClass('fa-minus')) {
+                        $('#%s .accordion-button.collapsed').click();
+                      }",
+                      session$ns("add_panel"),
+                      session$ns("dataset_filter_accordian")
+                    )
+                  )
+                ),
+                if (length(Filter(function(x) !x$anchored, self$get_filter_state())) > 0) {
+                  tags$div(
+                    style = "display: flex;",
+                    actionLink(
+                      session$ns("remove_filters"),
+                      label = "",
+                      icon = icon("far fa-circle-xmark"),
+                      class = "teal-slice filter-icon"
+                    )
+                  )
+                }
+              )
+            }
+          })
+
           lapply(
             names(private$get_filter_states()),
             function(x) {
@@ -350,18 +377,12 @@ FilteredDataset <- R6::R6Class( # nolint
             }
           )
 
-          is_filter_removable <- reactive({
-            non_anchored <- Filter(function(x) !x$anchored, self$get_filter_state())
-            isTRUE(length(non_anchored) > 0)
-          })
-
           private$session_bindings[[session$ns("get_filter_state")]] <- observeEvent(
             self$get_filter_state(),
             ignoreInit = TRUE,
             {
               shinyjs::hide("filter_count_ui")
               shinyjs::show("filters")
-              shinyjs::toggle("remove_filters_ui", condition = is_filter_removable())
               shinyjs::runjs(
                 sprintf(
                   "setAndRemoveClass('#%s', 'fa-angle-down', 'fa-angle-right')",
@@ -370,19 +391,6 @@ FilteredDataset <- R6::R6Class( # nolint
               )
             }
           )
-
-          output$remove_filters_ui <- renderUI({
-            req(is_filter_removable())
-            tags$div(
-              style = "display: flex;",
-              actionLink(
-                session$ns("remove_filters"),
-                label = "",
-                icon = icon("far fa-circle-xmark"),
-                class = "teal-slice filter-icon"
-              )
-            )
-          })
 
           # If the accordion input is `NULL` it is being collapsed.
           # It has the accordion panel label if it is expanded.
@@ -475,6 +483,7 @@ FilteredDataset <- R6::R6Class( # nolint
   ),
   # private fields ----
   private = list(
+    allow_add = NULL, # reactiveVal
     dataset = NULL, # data.frame or MultiAssayExperiment
     data_filtered = NULL,
     data_filtered_fun = NULL, # function

--- a/R/FilteredDatasetDataframe.R
+++ b/R/FilteredDatasetDataframe.R
@@ -192,6 +192,7 @@ DataframeFilteredDataset <- R6::R6Class( # nolint
         checkmate::assert_class(state, "teal_slices")
         state_datanames <- unique(vapply(state, `[[`, character(1L), "dataname"))
         checkmate::assert_subset(state_datanames, private$dataname)
+        super$set_filter_state(state = state)
         private$get_filter_states()[[1L]]$set_filter_state(state = state)
         invisible(NULL)
       })

--- a/R/FilteredDatasetMAE.R
+++ b/R/FilteredDatasetMAE.R
@@ -103,6 +103,7 @@ MAEFilteredDataset <- R6::R6Class( # nolint
         lapply(state, function(x) {
           checkmate::assert_true(x$dataname == private$dataname, .var.name = "dataname matches private$dataname")
         })
+        super$set_filter_state(state = state)
 
         # set state on subjects
         subject_state <- Filter(function(x) is.null(x$experiment), state)

--- a/man/FilteredDataset.Rd
+++ b/man/FilteredDataset.Rd
@@ -291,7 +291,7 @@ logical flag specifying whether the user will be able to add new filters}
 \subsection{Method \code{srv_active()}}{
 Server module for a dataset active filters.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$srv_active(id)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$srv_active(id, allow_add = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -299,6 +299,9 @@ Server module for a dataset active filters.
 \describe{
 \item{\code{id}}{(\code{character(1)})
 \code{shiny} module instance id.}
+
+\item{\code{allow_add}}{(\code{logical(1)})
+logical flag specifying whether the user will be able to add new filters}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/FilteredDataset.Rd
+++ b/man/FilteredDataset.Rd
@@ -267,7 +267,7 @@ Character string.
 \subsection{Method \code{ui_active()}}{
 \code{shiny} module containing active filters for a dataset, along with a title and a remove button.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$ui_active(id, allow_add = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$ui_active(id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -275,9 +275,6 @@ Character string.
 \describe{
 \item{\code{id}}{(\code{character(1)})
 \code{shiny} module instance id.}
-
-\item{\code{allow_add}}{(\code{logical(1)})
-logical flag specifying whether the user will be able to add new filters}
 }
 \if{html}{\out{</div>}}
 }
@@ -291,7 +288,7 @@ logical flag specifying whether the user will be able to add new filters}
 \subsection{Method \code{srv_active()}}{
 Server module for a dataset active filters.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$srv_active(id, allow_add = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FilteredDataset$srv_active(id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -299,9 +296,6 @@ Server module for a dataset active filters.
 \describe{
 \item{\code{id}}{(\code{character(1)})
 \code{shiny} module instance id.}
-
-\item{\code{allow_add}}{(\code{logical(1)})
-logical flag specifying whether the user will be able to add new filters}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
part of https://github.com/insightsengineering/coredev-tasks/issues/618
When `teal_slices(allow_add = TRUE)` then showing datasets with no filters in the Active Filters panel is unnecessary.


|  main | this  |
|---|---|
|  <img width="1512" alt="image" src="https://github.com/user-attachments/assets/58850196-8fa1-4277-a52d-56b2d4075aaf" /> |  <img width="1507" alt="image" src="https://github.com/user-attachments/assets/b8b6658c-5a79-4640-9221-5a0ec490ffb4" /> |

<details>
<summary> example app to play with </summary>

```r
options(teal.log_level = "TRACE", teal.show_js_log = TRUE)
pkgload::load_all("teal.slice")
library(teal)
library(scda)
library(SummarizedExperiment)

data <- teal_data() |> within({
  # MAE <- hermes::multi_assay_experiment
  ADSL <- synthetic_cdisc_data("latest")$adsl
  ADSL$empty <- NA
  ADSL$logical1 <- FALSE
  ADSL$logical <- sample(c(TRUE, FALSE), size = nrow(ADSL), replace = TRUE)
  ADSL$numeric <- rnorm(nrow(ADSL))
  ADSL$categorical <- sample(letters[1:10], size = nrow(ADSL), replace = TRUE)
  ADSL$date <- Sys.Date() + seq_len(nrow(ADSL))
  ADSL$datetime <- Sys.time() + seq_len(nrow(ADSL)) * 3600 * 12

  ADSL$numeric[sample(1:nrow(ADSL), size = 10, )] <- NA
  ADSL$numeric[sample(1:nrow(ADSL), size = 10, )] <- Inf
  ADSL$logical[sample(1:nrow(ADSL), size = 10, )] <- NA
  ADSL$date[sample(1:nrow(ADSL), size = 10, )] <- NA
  ADSL$datetime[sample(1:nrow(ADSL), size = 10, )] <- NA
  ADSL$categorical[sample(1:nrow(ADSL), size = 10, )] <- NA

  ADTTE <- synthetic_cdisc_data("latest")$adtte
  ADRS <- synthetic_cdisc_data("latest")$adrs
})

teal.data::join_keys(data) <- teal.data::default_cdisc_join_keys[teal.data::datanames(data)]

app <- init(
  data = data,
  modules = list(
    example_module("mod1"),
    modules(
      example_module("mod2")
    )
  ),
  filter = teal_slices(
    teal_slice("ADSL", "numeric"),
    teal_slice("ADSL", "categorical"),
    count_type = "all",
    allow_add = FALSE
  )
)

runApp(app)

```

</summary>