### PR TITLE
Improve the teal-slice sidebar

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -901,7 +901,7 @@ FilteredData <- R6::R6Class( # nolint
           tags$a(
             id = ns("show"),
             class = "available-menu",
-            bsicons::bs_icon("plus-square", size = "1.4rem", class = "teal-slice filter-icon"),
+            bsicons::bs_icon("plus-square", size = "1.4rem", class = "teal-slice filter-icon", fill = "#fff"),
           ),
           tags$div(
             class = "menu-content",

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -246,7 +246,7 @@ FilteredDataset <- R6::R6Class( # nolint
                 uiOutput(ns("remove_filters_ui"))
               ),
               bslib::page_fluid(
-                style = "padding: 0px 15px 0px 15px; margin: 0;",
+                style = "padding: 0; margin: 0;",
                 if (allow_add) {
                   tags$div(
                     id = ns("add_panel"),

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -582,12 +582,6 @@ a.remove_all:hover {
   position: relative;
   display: flex;
   z-index: 100;
-  opacity: 0.5;
-  transition: 0.1s;
-}
-
-.teal-slice.available-filters a:hover {
-  opacity: 1;
 }
 
 .teal-slice.available-filters .available-menu {
@@ -611,7 +605,6 @@ a.remove_all:hover {
 }
 
 .teal-slice.filter-icon.remove-all i {
-  opacity: 0.5;
   transition: 0.1s;
   color: var(--bs-danger);
 }
@@ -627,4 +620,8 @@ a.remove_all:hover {
 .teal-slice .accordion-button:not(.collapsed)::after,
 .accordion-button::after {
   scale: 0.8;
+}
+
+.teal-slice .accordion-body {
+  padding: 0;
 }


### PR DESCRIPTION
Companion of 

<details>
<summary> Sample app to test </summary>

```r
devtools::load_all('teal.slice')
library(shiny)
datasets <- init_filtered_data(list(iris = iris, mtcars = mtcars))
set_filter_state(
  datasets = datasets,
  filter = teal_slices(
    teal_slice(dataname = "iris", varname = "Species", selected = "virginica", keep_na = FALSE),
    teal_slice(dataname = "mtcars", id = "4 cyl", title = "4 Cylinders", expr = "cyl == 4"),
    teal_slice(dataname = "mtcars", varname = "mpg", selected = c(20.0, 25.0), keep_na = FALSE, keep_inf = FALSE),
    include_varnames = list(iris = c("Species", "Sepal.Length")),
    exclude_varnames = list(mtcars = "cyl"),
    count_type = "all",
    allow_add = TRUE
  )
)

ui <- bslib::page_fluid(
  fluidRow(
    column(
      width = 9,
      tabsetPanel(
        tabPanel(title = "iris", dataTableOutput("iris_table")),
        tabPanel(title = "mtcars", dataTableOutput("mtcars_table"))
      )
    ),
    column(width = 3, datasets$ui_filter_panel("filter_panel"))
  )
)
server <- function(input, output, session) {
  datasets$srv_filter_panel("filter_panel")
  iris_filtered_data <- reactive(datasets$get_data(dataname = "iris", filtered = TRUE))
  mtcars_filtered_data <- reactive(datasets$get_data(dataname = "mtcars", filtered = TRUE))
  output$iris_table <- renderDataTable(iris_filtered_data())
  output$mtcars_table <- renderDataTable(mtcars_filtered_data())
}

if (interactive()) {
  shinyApp(ui, server)
}
```

</details>

### Before
<img width="1470" alt="Screenshot 2025-04-24 at 10 37 25 AM" src="https://github.com/user-attachments/assets/9faba228-0d0b-498b-b9b0-01ae513e6e5e" />

### After
<img width="1470" alt="Screenshot 2025-04-24 at 10 36 46 AM" src="https://github.com/user-attachments/assets/615798fd-fb1d-45a3-bbbe-0a1b0b7fa18d" />
