### PR TITLE
chore: bump teal.logger dependency to 0.4.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     htmltools (>= 0.5.4),
     jsonlite (>= 2.0.0),
     lifecycle (>= 0.2.0),
-    logger (>= 0.3.0),
+    logger (>= 0.4.0),
     methods,
     plotly (>= 4.10.4),
     R6 (>= 2.2.0),


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.logger (>= 0.4.0) and removes it from Remotes.