### PR TITLE
fixes a warning

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -54,12 +54,12 @@ make_c_call <- function(choices) {
 #' @keywords internal
 .finalize_session_bindings <- function(self, private) {
   # Only finalize shiny session binding when there is an active session
-  if (
-    !is.null(getDefaultReactiveDomain()) &&
-      !getDefaultReactiveDomain()$isEnded()
-  ) {
-    lapply(private$session_bindings, function(x) x$destroy())
-  }
+  shiny::isolate({
+    rd <- getDefaultReactiveDomain()
+    if (!is.null(rd) && !rd$isEnded()) {
+      lapply(private$session_bindings, function(x) x$destroy())
+    }
+  })
   invisible(NULL)
 }
 


### PR DESCRIPTION
run `devtools::test("teal")`. You might see following output in a console. If no warning run `devtools::test("teal")`
 again in the same session.

```
Error in `.getReactiveEnvironment()$currentContext()`:
! Operation not allowed without an active reactive context.
• You tried to do something that can only be done from inside a reactive consumer.
Backtrace:
     ▆
  1. ├─shiny::testServer(...) at test-module_teal.R:1437:7
  2. │ └─session$close() at test-module_teal.R:1437:7
  3. │   ├─shiny::withReactiveDomain(...)
  4. │   │ └─promises::with_promise_domain(...)
  5. │   │   └─domain$wrapSync(expr)
  6. │   │     └─base::force(expr)
  7. │   └─private$endedCBs$invoke(onError = printError, ..stacktraceon = TRUE)
  8. │     ├─base::tryCatch(...)
  9. │     │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
 10. │     │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
 11. │     │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
 12. │     ├─shiny::captureStackTraces(if (..stacktraceon) ..stacktraceon..(callback(...)) else callback(...))
 13. │     │ └─promises::with_promise_domain(...)
 14. │     │   └─domain$wrapSync(expr)
 15. │     │     └─base::withCallingHandlers(expr, error = doCaptureStack)
 16. │     ├─shiny::..stacktraceon..(callback(...))
 17. │     └─shiny (local) callback(...)
 18. │       └─shiny (local) destroy()
 19. │         └─.ctx$invalidate()
 20. │           └─base::lapply(...)
 21. │             └─shiny (local) FUN(X[[i]], ...)
 22. │               └─shiny (local) func()
 23. │                 └─base::lapply(...)
 24. └─`<fn>`(`<DFFltrSt>`)
 25.   └─.subset2(e, "finalize")()
 26.     └─teal.slice:::.finalize_session_bindings(self, private)
 27.       └─base::lapply(private$session_bindings, function(x) x$destroy())
 28.         └─teal.slice (local) FUN(X[[i]], ...)
 29.           └─x$destroy()
 30.             ├─base::lapply(session$ns(names(input)), .subset2(input, "impl")$.values$remove)
 31.             ├─session$ns(names(input))
 32.             │ └─shiny (local) ns(namespace)
 33.             ├─base::names(input)
 34.             └─shiny:::names.reactivevalues(input)
 35.               └─.subset2(x, "impl")$names()
 36.                 └─.namesDeps$register()
 37.                   └─shiny:::getCurrentContext()
 38.                     └─.getReactiveEnvironment()$currentContext()
 39.                       └─rlang::abort(...)
```