### PR TITLE
Update lifecycle badges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,6 @@ repos:
           - grDevices
           - htmltools
           - jsonlite
-          - lifecycle
           - logger
           - methods
           - plotly

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,6 @@ Imports:
     grDevices,
     htmltools (>= 0.5.4),
     jsonlite (>= 2.0.0),
-    lifecycle (>= 0.2.0),
     logger (>= 0.4.0),
     methods,
     plotly (>= 4.10.4),
@@ -67,10 +66,8 @@ Suggests:
 VignetteBuilder:
     knitr,
     rmarkdown
-RdMacros:
-    lifecycle
 Config/Needs/verdepcheck: rstudio/shiny, rstudio/bslib, mllg/checkmate,
-    tidyverse/dplyr, rstudio/htmltools, jeroen/jsonlite, r-lib/lifecycle,
+    tidyverse/dplyr, rstudio/htmltools, jeroen/jsonlite,
     daroczig/logger, plotly/plotly, r-lib/R6, daattali/shinycssloaders,
     daattali/shinyjs, dreamRs/shinyWidgets, insightsengineering/teal.data,
     insightsengineering/teal.logger, insightsengineering/teal.widgets,

--- a/R/choices_labeled.R
+++ b/R/choices_labeled.R
@@ -1,6 +1,6 @@
 #' Set "`<choice>:<label>`" type of names
 #'
-#' @description `r lifecycle::badge("stable")`
+#' @description
 #'
 #' This is often useful for as it marks up the drop-down boxes for [shiny::selectInput()].
 #'

--- a/R/filter_panel_api.R
+++ b/R/filter_panel_api.R
@@ -1,6 +1,6 @@
 #' Managing `FilteredData` states
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Set, get and remove filter states of `FilteredData` object.
 #'

--- a/R/filter_panel_api.R
+++ b/R/filter_panel_api.R
@@ -155,7 +155,7 @@ clear_filter_states <- function(datasets, force = FALSE) {
 
 #' Gets filter expression for multiple `datanames` taking into account its order.
 #'
-#' @description `r lifecycle::badge("stable")`
+#' @description
 #'
 #' To be used in `Show R Code` button.
 #'

--- a/R/teal_slices.R
+++ b/R/teal_slices.R
@@ -17,7 +17,7 @@
 #' @param include_varnames,exclude_varnames (`named list`s of `character`) where list names
 #'  match names of data sets and vector elements match variable names in respective data sets;
 #'  specify which variables are allowed to be filtered; see `Details`.
-#' @param count_type `r lifecycle::badge("experimental")`
+#' @param count_type
 #' _This is a new feature. Do kindly share your opinions on
 #' [`teal.slice`'s GitHub repository](https://github.com/insightsengineering/teal.slice/)._
 #'

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -38,7 +38,6 @@
   dplyr::filter
   grDevices::rgb
   htmltools::tagInsertChildren
-  lifecycle::badge
   logger::log_debug
   plotly::plot_ly
   shinycssloaders::withSpinner

--- a/man/choices_labeled.Rd
+++ b/man/choices_labeled.Rd
@@ -22,8 +22,6 @@ match its order.}
 A named character vector.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
-
 This is often useful for as it marks up the drop-down boxes for \code{\link[shiny:selectInput]{shiny::selectInput()}}.
 }
 \details{

--- a/man/filter_state_api.Rd
+++ b/man/filter_state_api.Rd
@@ -36,8 +36,6 @@ containing a \code{teal_slice} for every existing \code{FilterState}
 }
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Set, get and remove filter states of \code{FilteredData} object.
 }
 \examples{

--- a/man/get_filter_expr.Rd
+++ b/man/get_filter_expr.Rd
@@ -15,7 +15,5 @@ get_filter_expr(datasets, datanames = datasets$datanames())
 A character string containing all subset expressions.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
-
 To be used in \verb{Show R Code} button.
 }

--- a/man/teal_slices.Rd
+++ b/man/teal_slices.Rd
@@ -19,8 +19,7 @@ teal_slices(
 match names of data sets and vector elements match variable names in respective data sets;
 specify which variables are allowed to be filtered; see \code{Details}.}
 
-\item{count_type}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-\emph{This is a new feature. Do kindly share your opinions on
+\item{count_type}{\emph{This is a new feature. Do kindly share your opinions on
 \href{https://github.com/insightsengineering/teal.slice/}{\code{teal.slice}'s GitHub repository}.}
 
 (\code{character(1)}) string specifying how observations are tallied by these filter states.


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/649

Removed stable badges.
Removed experimental badge 
    - introduced at 0.5.0 https://github.com/insightsengineering/teal.slice/pull/506
    - introduced between 0.3.0 - 0.4.0 https://github.com/insightsengineering/teal.slice/pull/165
    
Removed `lifecycle` at all
    - since there are no badges at this point anymore
