### PR TITLE
662 fix add experiment var

### DIFF
--- a/R/FilterStates.R
+++ b/R/FilterStates.R
@@ -418,15 +418,13 @@ FilterStates <- R6::R6Class( # nolint
     ui_add = function(id) {
       checkmate::assert_string(id)
       data <- private$data
-
       ns <- NS(id)
-
       if (ncol(data) == 0) {
-        tags$div("no sample variables available")
+        tags$div("dataset has no columns")
       } else if (nrow(data) == 0) {
-        tags$div("no samples available")
+        tags$div("dataset has now rows")
       } else {
-        uiOutput(ns("add_filter"))
+        uiOutput(ns("var_to_add_container"))
       }
     },
 
@@ -463,7 +461,7 @@ FilterStates <- R6::R6Class( # nolint
             )
           })
 
-          output$add_filter <- renderUI({
+          output$var_to_add_container <- renderUI({
             logger::log_debug(
               "{ class(self)[1] }$srv_add@1 updating available column choices, dataname: { private$dataname }"
             )

--- a/R/FilterStatesSE.R
+++ b/R/FilterStatesSE.R
@@ -102,19 +102,13 @@ SEFilterStates <- R6::R6Class( # nolint
       data <- private$data
       checkmate::assert_string(id)
       ns <- NS(id)
+
       row_input <- if (ncol(SummarizedExperiment::rowData(data)) == 0) {
-        tags$div("no sample variables available")
+        tags$div("no gene variables available")
       } else if (nrow(SummarizedExperiment::rowData(data)) == 0) {
-        tags$div("no samples available")
+        tags$div("no genes available")
       } else {
-        teal.widgets::optionalSelectInput(
-          ns("row_to_add"),
-          choices = NULL,
-          options = shinyWidgets::pickerOptions(
-            liveSearch = TRUE,
-            noneSelectedText = "Select gene variable"
-          )
-        )
+        uiOutput(ns("row_to_add_container"))
       }
 
       col_input <- if (ncol(SummarizedExperiment::colData(data)) == 0) {
@@ -122,20 +116,10 @@ SEFilterStates <- R6::R6Class( # nolint
       } else if (nrow(SummarizedExperiment::colData(data)) == 0) {
         tags$div("no samples available")
       } else {
-        teal.widgets::optionalSelectInput(
-          ns("col_to_add"),
-          choices = NULL,
-          options = shinyWidgets::pickerOptions(
-            liveSearch = TRUE,
-            noneSelectedText = "Select sample variable"
-          )
-        )
+        uiOutput(ns("col_to_add_container"))
       }
 
-      tags$div(
-        row_input,
-        col_input
-      )
+      tags$div(row_input, col_input)
     },
 
     #' @description
@@ -196,47 +180,49 @@ SEFilterStates <- R6::R6Class( # nolint
             )
           })
 
-          private$session_bindings[[session$ns("avail_row_data_choices")]] <- observeEvent(
-            avail_row_data_choices(),
-            ignoreNULL = TRUE,
-            handlerExpr = {
-              logger::log_debug(
-                "SEFilterStates$srv_add@1 updating available row data choices,",
-                "dataname: { private$dataname }"
-              )
-              if (is.null(avail_row_data_choices())) {
-                shinyjs::hide("row_to_add")
-              } else {
-                shinyjs::show("row_to_add")
-              }
-              teal.widgets::updateOptionalSelectInput(
-                session,
-                "row_to_add",
-                choices = avail_row_data_choices()
+          output$row_to_add_container <- renderUI({
+            logger::log_debug(
+              "{ class(self)[1] }$srv_add@1 updating available row data choices, dataname: { private$dataname }"
+            )
+            if (length(avail_row_data_choices()) == 0) {
+              # because input UI is not rendered on this condition but shiny still holds latest selected value
+              tags$span("No available columns to add.")
+            } else {
+              tags$div(
+                teal.widgets::optionalSelectInput(
+                  session$ns("row_to_add"),
+                  choices = avail_row_data_choices(),
+                  selected = NULL,
+                  options = shinyWidgets::pickerOptions(
+                    liveSearch = TRUE,
+                    noneSelectedText = "Select gene variable"
+                  )
+                )
               )
             }
-          )
+          })
 
-          private$session_bindings[[session$ns("avail_col_data_choices")]] <- observeEvent(
-            avail_col_data_choices(),
-            ignoreNULL = TRUE,
-            handlerExpr = {
-              logger::log_debug(
-                "SEFilterStates$srv_add@2 updating available col data choices,",
-                "dataname: { private$dataname }"
-              )
-              if (is.null(avail_col_data_choices())) {
-                shinyjs::hide("col_to_add")
-              } else {
-                shinyjs::show("col_to_add")
-              }
-              teal.widgets::updateOptionalSelectInput(
-                session,
-                "col_to_add",
-                choices = avail_col_data_choices()
+          output$col_to_add_container <- renderUI({
+            logger::log_debug(
+              "{ class(self)[1] }$srv_add@1 updating available col data choices, dataname: { private$dataname }"
+            )
+            if (length(avail_col_data_choices()) == 0) {
+              # because input UI is not rendered on this condition but shiny still holds latest selected value
+              tags$span("No available columns to add.")
+            } else {
+              tags$div(
+                teal.widgets::optionalSelectInput(
+                  session$ns("col_to_add"),
+                  choices = avail_col_data_choices(),
+                  selected = NULL,
+                  options = shinyWidgets::pickerOptions(
+                    liveSearch = TRUE,
+                    noneSelectedText = "Select sample variable"
+                  )
+                )
               )
             }
-          )
+          })
 
           private$session_bindings[[session$ns("col_to_add")]] <- observeEvent(
             eventExpr = input$col_to_add,

--- a/tests/testthat/test-FilterStates.R
+++ b/tests/testthat/test-FilterStates.R
@@ -364,7 +364,7 @@ testthat::test_that("ui_add returns a message inside a div when data has no colu
   filter_states <- FilterStates$new(data = data.frame(), dataname = "iris")
   testthat::expect_identical(
     filter_states$ui_add("id"),
-    shiny::div("no sample variables available")
+    shiny::div("dataset has no columns")
   )
 })
 

--- a/tests/testthat/test-SEFilterStates.R
+++ b/tests/testthat/test-SEFilterStates.R
@@ -105,7 +105,7 @@ testthat::test_that("ui_add returns a message inside a div when data has no rows
   testthat::expect_identical(
     filter_states$ui_add("id"),
     shiny::div(
-      shiny::div("no sample variables available"),
+      shiny::div("no gene variables available"),
       shiny::div("no sample variables available")
     )
   )
@@ -114,7 +114,7 @@ testthat::test_that("ui_add returns a message inside a div when data has no rows
   testthat::expect_identical(
     filter_states$ui_add("id"),
     shiny::div(
-      shiny::div("no samples available"),
+      shiny::div("no gene available"),
       shiny::div("no samples available")
     )
   )

--- a/tests/testthat/test-SEFilterStates.R
+++ b/tests/testthat/test-SEFilterStates.R
@@ -114,7 +114,7 @@ testthat::test_that("ui_add returns a message inside a div when data has no rows
   testthat::expect_identical(
     filter_states$ui_add("id"),
     shiny::div(
-      shiny::div("no gene available"),
+      shiny::div("no genes available"),
       shiny::div("no samples available")
     )
   )


### PR DESCRIPTION
- `observeEvent` + `update*` doesn't work well - I don't remember why but this is how it has been implemented for `DFFilterStates` and I should have been done in the same way for SummarizedExperiment. Here it the fix.
- I've also noticed that when data.frame has no rows or columns when ui says "No samples available" and term "samples" is for SummarisedExperiment not for data.frames (samples are columns in SE)

<details> 
<summary>app mixed</summary>

```r
options(teal.log_level = "TRACE", teal.show_js_log = TRUE)
pkgload::load_all("teal.slice")
library(teal)
library(scda)
library(SummarizedExperiment)

data <- teal_data() |> within({
  MAE <- hermes::multi_assay_experiment
  ADSL <- synthetic_cdisc_data("latest")$adsl
  ADSL$empty <- NA
  ADSL$logical1 <- FALSE
  ADSL$logical <- sample(c(TRUE, FALSE), size = nrow(ADSL), replace = TRUE)
  ADSL$numeric <- rnorm(nrow(ADSL))
  ADSL$categorical <- sample(letters[1:10], size = nrow(ADSL), replace = TRUE)
  ADSL$date <- Sys.Date() + seq_len(nrow(ADSL))
  ADSL$datetime <- Sys.time() + seq_len(nrow(ADSL)) * 3600 * 12

  ADSL$numeric[sample(1:nrow(ADSL), size = 10, )] <- NA
  ADSL$numeric[sample(1:nrow(ADSL), size = 10, )] <- Inf
  ADSL$logical[sample(1:nrow(ADSL), size = 10, )] <- NA
  ADSL$date[sample(1:nrow(ADSL), size = 10, )] <- NA
  ADSL$datetime[sample(1:nrow(ADSL), size = 10, )] <- NA
  ADSL$categorical[sample(1:nrow(ADSL), size = 10, )] <- NA

  ADTTE <- synthetic_cdisc_data("latest")$adtte
  ADRS <- synthetic_cdisc_data("latest")$adrs
})

teal.data::join_keys(data) <- teal.data::default_cdisc_join_keys[names(data)]

app <- init(
  data = data,
  modules = modules(
    example_module("mod1"),
    modules(
      label = "elo",
      example_module("mod2")
    )
  ),
  filter = teal_slices(
    teal_slice("ADSL", varname = "numeric"),
    teal_slice("ADSL", varname = "categorical"),
    teal_slice("ADSL", varname = "datetime"),
    teal_slice("ADSL", varname = "ARM"),
    teal_slice("ADSL", varname = "ARMCD"),
    teal_slice("MAE", experiment = "hd1", arg = "subset", varname = "size"),
    count_type = "all",
    allow_add = TRUE
  )
)

runApp(app)
```

</details>





<details> 
<summary>app MAE</summary>

```r
options(teal.log_level = "TRACE", teal.show_js_log = TRUE)
pkgload::load_all("teal.slice")
library(teal)
library(scda)
library(SummarizedExperiment)



default_filters <- teal_slices(
  teal_slice(dataname = "miniACC", experiment = "RPPAArray", arg = "subset", varname = "Genes", selected = "G6PD"),
  count_type = "all"
)

data <- teal_data() |> within(
  utils::data(miniACC, package = "MultiAssayExperiment", envir = environment())
)

app <- init(
  data = data,
  modules = list(example_module(), example_module("module2")),
  filter = default_filters
)

runApp(app)

```

</details>





<details> 
<summary>app hermes</summary>

```r
options(teal.log_level = "TRACE", teal.show_js_log = TRUE)
# options("teal.bs_theme" = bslib::bs_theme(version = 5))
# options(shiny.trace = TRUE)
devtools::load_all("teal.slice")
library(teal)
library(scda)
library(SummarizedExperiment)

default_filters <- teal_slices(
  teal_slice(dataname = "MAE", varname = "AGE"),
  teal_slice(dataname = "MAE", experiment = "hd1", arg = "select", varname = "low_depth_flag", selected = TRUE),
  teal_slice(dataname = "MAE", experiment = "hd1", arg = "select", varname = "tech_failure_flag"),
  include_varnames = list(MAE = c("AGE", "ARM")),
  count_type = "none"
)

MAE <- hermes::multi_assay_experiment

data <- teal.data::teal_data(MAE = MAE)

app <- init(
  data = data,
  modules = modules(example_module()),
  filter = default_filters
)

runApp(app)

```

</details>