### PR TITLE
Fix attribute when converting factors in ChoicesFilterState

### DIFF
--- a/R/FilterStateChoices.R
+++ b/R/FilterStateChoices.R
@@ -158,7 +158,9 @@ ChoicesFilterState <- R6::R6Class( # nolint
           combine = "or"
         )
         if (is.factor(x)) {
+          x_attributes <- attributes(x)
           x <- droplevels(x)
+          attributes(x) <- x_attributes
         }
         super$initialize(
           x = x,


### PR DESCRIPTION
Fixes #611

`droplevels()` was applied to avoid displaying unused levels in the filter. This dropped the attributes.
As a workaround, this PR restores the attributes after applying `droplevels()`. Please let me know if you would prefer a different approach.