### PR TITLE
Move "addd filter" button to work on touch-enabled screens

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,7 +78,7 @@ Config/Needs/verdepcheck: rstudio/shiny, rstudio/bslib, mllg/checkmate,
     bioc::SummarizedExperiment, rstudio/rmarkdown, r-lib/testthat,
     r-lib/withr, bioc::matrixStats
 Config/Needs/website: insightsengineering/nesttemplate
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0
 Encoding: UTF-8
 Language: en-US
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* Fixed placement of add filter button to avoid conflicting with sidebar resizing (#1714).
+* Fixed placement of add filter button to avoid conflicting with sidebar resizing (#694).
 
 # teal.slice 0.8.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 # teal.slice 0.8.2.9000
 
+### Bug fixes
+
+* Fixed placement of add filter button to avoid conflicting with sidebar resizing (#1714).
+
 # teal.slice 0.8.2
 
-* Fixed shiny session clean up due to `shiny` package update (#682)
+* Fixed shiny session clean up due to `shiny` package update (#682).
 
 # teal.slice 0.8.1
 

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -251,7 +251,7 @@ DateFilterState <- R6::R6Class( # nolint
     },
     remove_out_of_bounds_values = function(values) {
       choices <- private$get_choices()
-      if (values[1] < choices[1L] | values[1] > choices[2L]) {
+      if (values[1] < choices[1L] || values[1] > choices[2L]) {
         warning(
           sprintf(
             "Value: %s is outside of the possible range for column %s of dataset %s, setting minimum possible value.",
@@ -261,7 +261,7 @@ DateFilterState <- R6::R6Class( # nolint
         values[1] <- choices[1L]
       }
 
-      if (values[2] > choices[2L] | values[2] < choices[1L]) {
+      if (values[2] > choices[2L] || values[2] < choices[1L]) {
         warning(
           sprintf(
             "Value: %s is outside of the possible range for column %s of dataset %s, setting maximum possible value.",

--- a/R/FilterStateDate.R
+++ b/R/FilterStateDate.R
@@ -116,7 +116,6 @@ DateFilterState <- R6::R6Class( # nolint
   # public methods ----
 
   public = list(
-
     #' @description
     #' Initialize a `FilterState` object.
     #'

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -122,7 +122,6 @@ DatetimeFilterState <- R6::R6Class( # nolint
   # public methods ----
 
   public = list(
-
     #' @description
     #' Initialize a `FilterState` object. This class
     #' has an extra field, `private$timezone`, which is set to `Sys.timezone()` by

--- a/R/FilterStateDatettime.R
+++ b/R/FilterStateDatettime.R
@@ -297,7 +297,7 @@ DatetimeFilterState <- R6::R6Class( # nolint
         values[1] <- choices[1L]
       }
 
-      if (values[2] > choices[2L] | values[2] < choices[1L]) {
+      if (values[2] > choices[2L] || values[2] < choices[1L]) {
         warning(
           sprintf(
             "Value: '%s' is outside of the range for the column '%s' in dataset '%s', setting maximum possible value.",

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -892,7 +892,8 @@ FilteredData <- R6::R6Class( # nolint
             id = ns("show"),
             class = "available-menu",
             bsicons::bs_icon(
-              "plus-square", class = "teal-slice filter-icon", fill = "#fff", height = "1.41rem", width = "1.4rem"
+              "plus-square",
+              class = "teal-slice filter-icon", fill = "#fff", height = "1.41rem", width = "1.4rem"
             ),
           ),
           tags$div(

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -891,7 +891,7 @@ FilteredData <- R6::R6Class( # nolint
           tags$a(
             id = ns("show"),
             class = "available-menu",
-            bsicons::bs_icon("plus-square", size = "1.4rem", class = "teal-slice filter-icon", fill = "#fff"),
+            bsicons::bs_icon("plus-square", class = "teal-slice filter-icon", fill = "#fff", height = "1.41rem", width = "1.4rem"),
           ),
           tags$div(
             style = "min-width: 15em;",

--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -891,7 +891,9 @@ FilteredData <- R6::R6Class( # nolint
           tags$a(
             id = ns("show"),
             class = "available-menu",
-            bsicons::bs_icon("plus-square", class = "teal-slice filter-icon", fill = "#fff", height = "1.41rem", width = "1.4rem"),
+            bsicons::bs_icon(
+              "plus-square", class = "teal-slice filter-icon", fill = "#fff", height = "1.41rem", width = "1.4rem"
+            ),
           ),
           tags$div(
             style = "min-width: 15em;",

--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -249,12 +249,12 @@ FilteredDataset <- R6::R6Class( # nolint
                     id = session$ns("dataset_filter_accordion"),
                     class = "teal-slice-dataset-filter",
                     bslib::accordion_panel(
-                      dataname,
+                      tags$span(dataname, uiOutput(session$ns("active_filter_badge"))),
+                      value = dataname,
                       style = "padding: 0; margin: 0;",
                       bslib::page_fluid(
                         id = session$ns("whole_ui"),
                         style = "margin: 0; padding: 0;",
-                        uiOutput(session$ns("active_filter_badge")),
                         div(
                           id = session$ns("filter_util_icons"),
                           class = "teal-slice filter-util-icons",
@@ -309,22 +309,13 @@ FilteredDataset <- R6::R6Class( # nolint
                       )
                     )
                   ),
+                  # We need to dynamically move filter_util_icons as they cannot be created in header without
+                  # preventing the click event to propapagate and collapse/show the accordion.
                   tags$script(
                     HTML(
                       sprintf(
-                        "
-            $(document).ready(function() {
-              $('#%s').appendTo('#%s > .accordion-item > .accordion-header');
-              $('#%s > .accordion-item > .accordion-header').css({
-                'display': 'flex'
-              });
-              $('#%s').appendTo('#%s .accordion-header .accordion-title');
-            });
-          ",
+                        "$(document).ready(() => $('#%s').appendTo('#%s > .accordion-item > .accordion-header'))",
                         session$ns("filter_util_icons"),
-                        session$ns("dataset_filter_accordion"),
-                        session$ns("dataset_filter_accordion"),
-                        session$ns("active_filter_badge"),
                         session$ns("dataset_filter_accordion")
                       )
                     )

--- a/inst/css/filter-panel.css
+++ b/inst/css/filter-panel.css
@@ -289,10 +289,20 @@
   align-items: center;
   width: 3.5rem;
   margin-left: -4rem;
+  padding-right: 8px;
+}
+
+.teal-slice-dataset-filter .accordion-item .accordion-title {
+  padding-left: 8px;
+  width: 100%;
+}
+
+.teal-slice-dataset-filter .accordion-item > .accordion-header {
+  display: flex;
 }
 
 .teal-slice.filter-util-icons a {
-  z-index: 100;
+  z-index: calc(1000 + 2); /* Above bslib sidebar resize handler */
 }
 
 .teal-slice.filter-util-icons .filter-icon {
@@ -314,7 +324,7 @@
 .teal-slice.available-filters a {
   position: relative;
   display: flex;
-  z-index: 100;
+  z-index: calc(1000 + 2); /* Above bslib sidebar resize handler */
 }
 
 .teal-slice.available-filters .available-menu {


### PR DESCRIPTION
# Pull Request

Fixes #694 

### Changes description

- "+" button is now clickable on touch screens
  - Improved vertical alignment with other icons
- Fixed visual glitch on a adjacent button (see screenshot below)
- Moved badge to header to avoid JS tricks
- Adds comment justifying JS tricks

### Example

```r
library(teal)

theme <- bslib::bs_theme(version = 5)
options(teal.bs_theme = theme)


demo_data <- cdisc_data()
demo_data <- within(demo_data, {
  ADSL <- data.frame(
    USUBJID = paste0("SUBJ", sprintf("%03d", 1:20)),
    AGE = c(25, 35, 45, 55, 65, 75, 30, 40, 50, 60,
            28, 38, 48, 58, 68, 32, 42, 52, 62, 72),
    SEX = as.factor(rep(c("M", "F"), 10)),
    ARM = as.factor(rep(c("Placebo", "Treatment"), each = 10)),
    SAFFL = "Y"
  )
  
  ADAE <- data.frame(
    USUBJID = rep(ADSL$USUBJID[1:15], each = 2),  # Only first 15 subjects have AEs
    AESEQ = rep(1:2, 15),
    AEDECOD = sample(c("Headache", "Nausea", "Fatigue"), 30, replace = TRUE),
    AESEV = as.factor(sample(c("MILD", "MODERATE"), 30, replace = TRUE))
  )
})

teal::init(data = demo_data, modules = teal::example_module()) |>
  shiny::runApp()
```

<img width="300" height="136" alt="image" src="https://github.com/user-attachments/assets/69aeda80-abeb-42d1-b48a-543ff36abc49" />
